### PR TITLE
Client render status of transaction based on intent status

### DIFF
--- a/src/cashier_frontend/src/components/confirmation-popup.tsx
+++ b/src/cashier_frontend/src/components/confirmation-popup.tsx
@@ -154,6 +154,7 @@ const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
                 assets={mainIntents?.map((intent) =>
                     mapIntentModelToAssetModel(intent, data?.transactions),
                 )}
+                state={mainIntents![0].state}
             />
         );
     };
@@ -163,6 +164,7 @@ const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
             <TransactionItem
                 title={translate("transaction.confirm_popup.cashier_fee_label")}
                 assets={[mapIntentModelToAssetModel(cashierFeeIntents![0], data?.transactions)]}
+                state={cashierFeeIntents![0].state}
             />
         );
     };
@@ -191,13 +193,6 @@ const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
             ));
         }
     };
-
-    // useEffect(() => {
-    //     if (networkFees.length > 0 || totalFees.length > 0) {
-    //         //setNetworkFees(groupFeesByAddress(networkFees));
-    //         setLoading(false);
-    //     }
-    // }, [networkFees, totalFees]);
 
     return (
         <DrawerContent className="max-w-[400px] mx-auto p-3">

--- a/src/cashier_frontend/src/components/confirmation-popup.tsx
+++ b/src/cashier_frontend/src/components/confirmation-popup.tsx
@@ -1,20 +1,20 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { DrawerContent, DrawerHeader, DrawerTitle } from "./ui/drawer";
 import { Button } from "./ui/button";
 import TransactionItem, { AssetModel } from "./transaction-item";
 import { IoIosClose } from "react-icons/io";
 import { useTranslation } from "react-i18next";
-import { CreateIntentConsentModel, TransactionModel } from "@/services/types/intent.service.types";
-import { mapFeeModelToAssetModel } from "@/services/types/mapper/intent.service.mapper";
-import { LINK_ASSET_TYPE } from "@/services/types/enum";
+import { TransactionModel } from "@/services/types/intent.service.types";
+import { mapIntentModelToAssetModel } from "@/services/types/mapper/intent.service.mapper";
+import { TASK } from "@/services/types/enum";
 import { TokenUtilService } from "@/services/tokenUtils.service";
 import { Skeleton } from "./ui/skeleton";
 import { ActionModel } from "@/services/types/refractor.action.service.types";
+import { LinkModel } from "@/services/types/link.service.types";
 
-/*TODO: Update this model to accept "linkData" and "action" */
 export type ConfirmTransactionModel = {
     linkName: string;
-    feeModel: CreateIntentConsentModel;
+    linkData: LinkModel;
     action: ActionModel;
     transactions?: TransactionModel[][];
 };
@@ -27,7 +27,6 @@ interface ConfirmationPopupProps {
     buttonText: string;
 }
 
-/*TODO: The confirmation popup should receive "data" include "linkData" and "action" to display conent on the UI */
 const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
     data,
     handleClose,
@@ -39,6 +38,18 @@ const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
     const [networkFees, setNetworkFees] = useState<AssetModel[]>([]);
     const [totalFees, setTotalFees] = useState<(AssetModel | undefined)[]>([]);
     const [isLoading, setLoading] = useState<boolean>(true);
+
+    const mainIntents = useMemo(() => {
+        return data?.action.intents.filter(
+            (intent) => intent.task === TASK.TRANSFER_WALLET_TO_LINK,
+        );
+    }, [data?.action.intents]);
+
+    const cashierFeeIntents = useMemo(() => {
+        return data?.action.intents.filter(
+            (intent) => intent.task === TASK.TRANSFER_WALLET_TO_TREASURY,
+        );
+    }, [data?.action.intents]);
 
     const processAllTheFees = async () => {
         // Network fee from sending assets
@@ -55,54 +66,63 @@ const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
 
     // Get network fees from each asset sending and included them in total fees
     const processFeesFromAssetSending = async (): Promise<(AssetModel | undefined)[]> => {
-        let totalFees: (AssetModel | undefined)[] = [];
-        if (data?.feeModel?.send?.length) {
-            for (let i = 0; i < data?.feeModel.send.length; i++) {
-                const tokenMetadata = await TokenUtilService.getTokenMetadata(
-                    data?.feeModel.send[i].address,
-                );
-                if (tokenMetadata) {
-                    const networkFeeFromSendAsset: AssetModel = {
-                        address: data?.feeModel.send[i].address,
-                        amount: tokenMetadata.fee,
-                        chain: data?.feeModel.send[i].chain,
-                    };
-                    totalFees = totalFees.concat([
-                        mapFeeModelToAssetModel(data?.feeModel.send[i], undefined),
-                        networkFeeFromSendAsset,
-                    ]);
-                    setNetworkFees((prevFees) => [...prevFees, networkFeeFromSendAsset]);
-                }
-            }
+        if (!mainIntents) return [];
+
+        const totalFees: AssetModel[] = [];
+
+        for (const intent of mainIntents) {
+            const tokenMetadata = await TokenUtilService.getTokenMetadata(intent.asset.address);
+
+            if (!tokenMetadata) continue;
+
+            const networkFeeFromSendAsset: AssetModel = {
+                address: intent.asset.address,
+                amount: tokenMetadata.fee,
+                chain: intent.asset.chain,
+            };
+
+            setNetworkFees((prevFees) => [...prevFees, networkFeeFromSendAsset]);
+
+            totalFees.concat([
+                mapIntentModelToAssetModel(intent, undefined)!,
+                networkFeeFromSendAsset,
+            ]);
         }
+
         return totalFees;
     };
 
     // Get network fees from cashier fee and included them in total fees
     const processFeesFromCashierFee = async (): Promise<(AssetModel | undefined)[]> => {
-        let totalFees: (AssetModel | undefined)[] = [];
-        if (data?.feeModel?.fee[0]?.address) {
-            const cashierFeeTokenMetadata = await TokenUtilService.getTokenMetadata(
-                data?.feeModel.fee[0].address,
-            );
-            if (cashierFeeTokenMetadata) {
-                const networkFeeFromCashierFee: AssetModel = {
-                    address: data?.feeModel.fee[0].address,
-                    amount: cashierFeeTokenMetadata.fee,
-                    chain: data?.feeModel.fee[0].chain,
-                };
-                totalFees = totalFees.concat([
-                    mapFeeModelToAssetModel(data?.feeModel.fee[0], undefined),
-                    networkFeeFromCashierFee,
-                ]);
-                setNetworkFees((prevFees) => [...prevFees, networkFeeFromCashierFee]);
-            }
+        if (!cashierFeeIntents) return [];
+
+        const totalFees: (AssetModel | undefined)[] = [];
+
+        for (const intent of cashierFeeIntents) {
+            const tokenMetadata = await TokenUtilService.getTokenMetadata(intent.asset.address);
+
+            if (!tokenMetadata) continue;
+
+            const networkFeeFromSendAsset: AssetModel = {
+                address: intent.asset.address,
+                amount: intent.amount,
+                chain: intent.asset.chain,
+            };
+
+            setNetworkFees((prevFees) => [...prevFees, networkFeeFromSendAsset]);
+
+            totalFees.concat([
+                mapIntentModelToAssetModel(intent, undefined)!,
+                networkFeeFromSendAsset,
+            ]);
         }
+
         return totalFees;
     };
 
     const groupFeesByAddress = (feeList: (AssetModel | undefined)[]): AssetModel[] => {
         const feeMap = new Map<string, AssetModel>();
+
         feeList.forEach((fee) => {
             if (fee) {
                 const existingFee = feeMap.get(fee.address);
@@ -113,6 +133,7 @@ const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
                 }
             }
         });
+
         return Array.from(feeMap.values());
     };
 
@@ -120,10 +141,31 @@ const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
         const processFees = async () => {
             if (data && !networkFees.length && !totalFees.length) {
                 await processAllTheFees();
+                setLoading(false);
             }
         };
         processFees();
     }, [data]);
+
+    const renderMainAssets = () => {
+        return (
+            <TransactionItem
+                title="Asset to add to link"
+                assets={mainIntents?.map((intent) =>
+                    mapIntentModelToAssetModel(intent, data?.transactions),
+                )}
+            />
+        );
+    };
+
+    const renderCashierFees = () => {
+        return (
+            <TransactionItem
+                title={translate("transaction.confirm_popup.cashier_fee_label")}
+                assets={[mapIntentModelToAssetModel(cashierFeeIntents![0], data?.transactions)]}
+            />
+        );
+    };
 
     const renderNetworkFees = () => {
         if (networkFees.length > 0) {
@@ -150,12 +192,12 @@ const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
         }
     };
 
-    useEffect(() => {
-        if (networkFees.length > 0 && totalFees.length > 0) {
-            setNetworkFees(groupFeesByAddress(networkFees));
-            setLoading(false);
-        }
-    }, [networkFees, totalFees]);
+    // useEffect(() => {
+    //     if (networkFees.length > 0 || totalFees.length > 0) {
+    //         //setNetworkFees(groupFeesByAddress(networkFees));
+    //         setLoading(false);
+    //     }
+    // }, [networkFees, totalFees]);
 
     return (
         <DrawerContent className="max-w-[400px] mx-auto p-3">
@@ -201,25 +243,10 @@ const ConfirmationPopup: React.FC<ConfirmationPopupProps> = ({
                             style={{ maxHeight: "200px", overflowY: "auto" }}
                         >
                             {/* ---- LINK ASSET ---  */}
-                            <TransactionItem
-                                title="Asset to add to link"
-                                assets={data?.feeModel.send.map((asset) =>
-                                    mapFeeModelToAssetModel(asset, data?.transactions),
-                                )}
-                            />
+                            {renderMainAssets()}
                             <div className="mt-1">
                                 {/* ---- CASHIER FEES ---  */}
-                                <TransactionItem
-                                    title={translate("transaction.confirm_popup.cashier_fee_label")}
-                                    assets={[
-                                        mapFeeModelToAssetModel(
-                                            data?.feeModel.fee.find(
-                                                (f) => f.type === LINK_ASSET_TYPE.CASHIER_FEE,
-                                            ),
-                                            data?.transactions,
-                                        ),
-                                    ]}
-                                />
+                                {renderCashierFees()}
                                 {/* ---- NETWORK FEES ---  */}
                                 {renderNetworkFees()}
                             </div>

--- a/src/cashier_frontend/src/components/transaction-item.tsx
+++ b/src/cashier_frontend/src/components/transaction-item.tsx
@@ -6,7 +6,7 @@ import { FC, useEffect, useState } from "react";
 import { IoMdClose } from "react-icons/io";
 import { IoMdCheckmark } from "react-icons/io";
 import { TransactionModel } from "@/services/types/intent.service.types";
-import { TRANSACTION_STATE } from "@/services/types/enum";
+import { INTENT_STATE, TRANSACTION_STATE } from "@/services/types/enum";
 
 export type AssetModel = {
     address: string;
@@ -49,15 +49,15 @@ const TransactionItem: FC<TransactionItemProps> = ({
 
     const renderTransactionState = (transactionState?: string) => {
         switch (transactionState) {
-            case TRANSACTION_STATE.SUCCESS:
+            case INTENT_STATE.SUCCESS:
                 return <IoMdCheckmark color="green" size={22} />;
-            case TRANSACTION_STATE.FAIL:
-            case TRANSACTION_STATE.TIMEOUT:
+            case INTENT_STATE.FAIL:
+            case INTENT_STATE.TIMEOUT:
                 return <IoMdClose color="red" size={22} />;
-            case TRANSACTION_STATE.PROCESSING:
+            case INTENT_STATE.PROCESSING:
                 return <img src="/loading.gif" width={22} />;
             default:
-                return <IoMdCheckmark color="green" size={22} className="opacity-0 hidden" />;
+                return <IoMdCheckmark color="green" size={22} className="opacity-0" />;
         }
     };
 
@@ -76,7 +76,7 @@ const TransactionItem: FC<TransactionItemProps> = ({
     return (
         <div id="confirmation-transaction" className="flex justify-between my-2">
             <div className="flex">
-                {renderTransactionState(assets?.[0]?.transaction?.state)}
+                {renderTransactionState(state)}
                 <div id="transaction-title" className="ml-3 text-right">
                     {title}
                 </div>

--- a/src/cashier_frontend/src/components/transaction-item.tsx
+++ b/src/cashier_frontend/src/components/transaction-item.tsx
@@ -23,22 +23,29 @@ interface TransactionItemProps {
     isLoading?: boolean;
 }
 
-const TransactionItem: FC<TransactionItemProps> = (props) => {
+const TransactionItem: FC<TransactionItemProps> = ({
+    title,
+    assets,
+    state,
+    isNetWorkFee,
+    isLoading,
+}) => {
     const [tokenSymbol, setTokenSymbol] = useState<string>("");
     const [displayAmount, setDisplayAmount] = useState<number>(0);
     const { data: tokenData, isLoading: isLoadingMetadata } = useTokenMetadataQuery(
-        props?.assets?.[0]?.address,
+        assets?.[0]?.address,
     );
 
     useEffect(() => {
-        if (tokenData && props.assets?.[0]) {
-            const amount = props.assets?.[0]?.amount;
+        if (tokenData && assets?.[0]) {
+            const amount = assets?.[0]?.amount;
+
             setDisplayAmount(
                 convertDecimalBigIntToNumber(amount ?? BigInt(0), tokenData.metadata.decimals),
             );
             setTokenSymbol(tokenData.metadata.symbol ?? "");
         }
-    }, [tokenData, props.assets, props.isNetWorkFee]);
+    }, [tokenData, assets, isNetWorkFee]);
 
     const renderTransactionState = (transactionState?: string) => {
         switch (transactionState) {
@@ -54,26 +61,28 @@ const TransactionItem: FC<TransactionItemProps> = (props) => {
         }
     };
 
-    const assetItem = () => (
-        <div className="flex">
-            {`${displayAmount} ${tokenSymbol}`}
-            <Avatar className="w-7 h-7 ml-3">
-                <AvatarImage src={`${IC_EXPLORER_IMAGES_PATH}${props?.assets?.[0]?.address}`} />
-                <AvatarFallback>{tokenData?.metadata?.symbol}</AvatarFallback>
-            </Avatar>
-        </div>
-    );
+    const assetItem = () => {
+        return (
+            <div className="flex">
+                {`${displayAmount} ${tokenSymbol}`}
+                <Avatar className="w-7 h-7 ml-3">
+                    <AvatarImage src={`${IC_EXPLORER_IMAGES_PATH}${assets?.[0]?.address}`} />
+                    <AvatarFallback>{tokenData?.metadata?.symbol}</AvatarFallback>
+                </Avatar>
+            </div>
+        );
+    };
 
     return (
         <div id="confirmation-transaction" className="flex justify-between my-2">
             <div className="flex">
-                {renderTransactionState(props.assets?.[0]?.transaction?.state)}
+                {renderTransactionState(assets?.[0]?.transaction?.state)}
                 <div id="transaction-title" className="ml-3 text-right">
-                    {props.title}
+                    {title}
                 </div>
             </div>
             <div>
-                {props.isLoading || isLoadingMetadata ? (
+                {isLoading || isLoadingMetadata ? (
                     <img src="/loading.gif" width={22} />
                 ) : (
                     assetItem()

--- a/src/cashier_frontend/src/locales/en.json
+++ b/src/cashier_frontend/src/locales/en.json
@@ -59,6 +59,7 @@
             "transaction_failed": "Transaction failed",
             "transaction_failed_message": "Retry failed transaction",
             "transaction_success": "Transaction success",
+            "transaction_success_message": "",
             "legal_text": "By confirming you agree to execute the transaction above and agree to the terms of service"
         }
     },

--- a/src/cashier_frontend/src/pages/edit/[id]/index.tsx
+++ b/src/cashier_frontend/src/pages/edit/[id]/index.tsx
@@ -73,10 +73,6 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
     });
 
     useEffect(() => {
-        console.log(linkData);
-    }, [linkData]);
-
-    useEffect(() => {
         if (linkData) {
             const { link, intent_create, action } = linkData;
 
@@ -283,11 +279,9 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
         setPopupButton(t("transaction.confirm_popup.inprogress_button"));
         const intentService = new IntentService(identity);
 
-        console.log(linkId, linkData?.action?.intents[0].id);
         const confirmItemResult = await intentService.confirmIntent(
             linkId ?? "",
-            //intentCreate?.id ?? "",
-            linkData?.action?.intents[0].id ?? "",
+            intentCreate?.id ?? "",
         );
 
         if (confirmItemResult?.transactions) {
@@ -327,18 +321,18 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
     const handleConfirmTransactions = async () => {
         if (!linkId && !intentCreate?.id) return;
 
-        console.log("Call confirm");
-        try {
-            if (linkData?.intent_create?.state === INTENT_STATE.SUCCESS) {
-                await handleUpdateLinkToActive();
-            } else if (linkData?.intent_create?.state === INTENT_STATE.FAIL) {
-                handleRetryTransactions();
-            } else {
-                await startTransaction();
-            }
-        } catch (err) {
-            console.error(err);
-        }
+        // console.log("Call confirm");
+        // try {
+        //     if (linkData?.intent_create?.state === INTENT_STATE.SUCCESS) {
+        //         await handleUpdateLinkToActive();
+        //     } else if (linkData?.intent_create?.state === INTENT_STATE.FAIL) {
+        //         handleRetryTransactions();
+        //     } else {
+        //         await startTransaction();
+        //     }
+        // } catch (err) {
+        //     console.error(err);
+        // }
     };
 
     const handleBackstep = async () => {

--- a/src/cashier_frontend/src/pages/edit/[id]/index.tsx
+++ b/src/cashier_frontend/src/pages/edit/[id]/index.tsx
@@ -18,10 +18,6 @@ import { getReponsiveClassname } from "@/utils";
 import { responsiveMapper } from "./index_responsive";
 import { z } from "zod";
 import { INTENT_STATE, LINK_STATE, LINK_TYPE } from "@/services/types/enum";
-import {
-    CreateIntentInput,
-    GetConsentMessageInput,
-} from "../../../../../declarations/cashier_backend/cashier_backend.did";
 import { IntentCreateModel, TransactionModel } from "@/services/types/intent.service.types";
 import IntentService from "@/services/intent.service";
 import SignerService from "@/services/signer.service";
@@ -77,37 +73,68 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
     });
 
     useEffect(() => {
+        console.log(linkData);
+    }, [linkData]);
+
+    useEffect(() => {
         if (linkData) {
-            console.log(linkData);
             const { link, intent_create, action } = linkData;
+
             if (link && link.state) {
                 const step = STEP_LINK_STATE_ORDER.findIndex((x) => x === link.state);
                 setFormData(link);
                 setRendering(false);
                 setCurrentStep(step >= 0 ? step : 0);
             }
+
             if (intent_create && action) {
                 setIntentCreate(intent_create);
                 setLinkAction(action);
-                /* TODO: Update this setTransactionConfirmModel */
-                // setTransactionConfirmModel(
-                //     (prevModel) =>
-                //         ({
-                //             ...prevModel,
-                //             transactions: linkData?.intent_create?.transactions,
-                //         }) as ConfirmTransactionModel,
-                // );
+                setTransactionConfirmModel(
+                    (prevModel) =>
+                        ({
+                            ...prevModel,
+                            linkData: linkData,
+                            action: linkAction,
+                            transactions: linkData?.intent_create?.transactions,
+                        }) as ConfirmTransactionModel,
+                );
             }
         }
 
-        /*TODO: Update the button state based on the intent state */
+        if (linkData?.intent_create?.state === INTENT_STATE.CREATED) {
+            setPopupButton(t("transaction.confirm_popup.confirm_button"));
+            setDisabledConfirmButton(false);
+        }
+
+        if (
+            linkData?.intent_create?.state === INTENT_STATE.PROCESSING ||
+            linkData?.intent_create?.state === INTENT_STATE.TIMEOUT
+        ) {
+            setPopupButton(t("transaction.confirm_popup.inprogress_button"));
+            setDisabledConfirmButton(true);
+        }
+
         if (linkData?.intent_create?.state === INTENT_STATE.SUCCESS) {
             setPopupButton(t("continue"));
             setDisabledConfirmButton(false);
+
+            showToast(
+                t("transaction.confirm_popup.transaction_success"),
+                t("transaction.confirm_popup.transaction_success_message"),
+                "default",
+            );
         }
+
         if (linkData?.intent_create?.state === INTENT_STATE.FAIL) {
             setPopupButton(t("Retry"));
             setDisabledConfirmButton(false);
+
+            showToast(
+                t("transaction.confirm_popup.transaction_failed"),
+                t("transaction.validation.transaction_failed_message"),
+                "error",
+            );
         }
     }, [linkData]);
 
@@ -158,35 +185,17 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
         }
     };
 
-    /*TODO: Update this function: remove the createActionInput param*/
-    const handleCreateAction = async (
-        linkService: LinkService,
-        createActionInput: CreateIntentInput,
-    ) => {
-        const intentCreateConsentInput: GetConsentMessageInput = {
-            link_id: linkId ?? "",
-            intent_type: "Create",
-            params: [],
-            intent_id: intentCreate?.id ?? "",
-        };
+    const handleCreateAction = async (linkService: LinkService) => {
+        const action = await linkService.createAction();
 
-        /*TODO: Consider to remove the "consent" variable */
-        const consent = intentCreate
-            ? await linkService.getConsentMessage(intentCreateConsentInput)
-            : await linkService.createAction(createActionInput).then((result) => {
-                  setLinkAction(result);
-              });
-
-        const action = linkAction ?? (await linkService.createAction(createActionInput));
         if (action) {
             setLinkAction(action);
         }
 
-        /*TODO: Use the "action" instead of "consent" to pass into the ConfirmTransactionModel */
-        if (consent) {
+        if (action) {
             const transactionConfirmObj: ConfirmTransactionModel = {
                 linkName: formData.title ?? "",
-                feeModel: consent,
+                linkData: linkData!,
                 transactions: intentCreate?.transactions,
                 action: action,
             };
@@ -198,18 +207,16 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
     // User click "Create" button
     const handleSubmit = async () => {
         if (!linkId) return;
+
         const validationResult = true;
+
         try {
             if (validationResult) {
                 const linkService = new LinkService(identity);
-                setDisabled(true);
-                const createActionInput: CreateIntentInput = {
-                    link_id: linkId ?? "",
-                    intent_type: "Create",
-                    params: [],
-                };
 
-                await handleCreateAction(linkService, createActionInput);
+                setDisabled(true);
+
+                await handleCreateAction(linkService);
             } else {
                 showToast(
                     t("transaction.validation.action_failed"),
@@ -275,24 +282,29 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
         setDisabledConfirmButton(true);
         setPopupButton(t("transaction.confirm_popup.inprogress_button"));
         const intentService = new IntentService(identity);
-        const confirmItenResult = await intentService.confirmIntent(
+
+        console.log(linkId, linkData?.action?.intents[0].id);
+        const confirmItemResult = await intentService.confirmIntent(
             linkId ?? "",
-            intentCreate?.id ?? "",
+            //intentCreate?.id ?? "",
+            linkData?.action?.intents[0].id ?? "",
         );
-        if (confirmItenResult?.transactions) {
+
+        if (confirmItemResult?.transactions) {
             // Change transaction status to processing
             setIntentCreate(
                 (prev) =>
                     ({
                         ...prev,
-                        transactions: confirmItenResult?.transactions,
+                        transactions: confirmItemResult?.transactions,
                     }) as IntentCreateModel,
             );
+
             setTransactionConfirmModel(
                 (prevModel) =>
                     ({
                         ...prevModel,
-                        transactions: confirmItenResult?.transactions,
+                        transactions: confirmItemResult?.transactions,
                     }) as ConfirmTransactionModel,
             );
 
@@ -314,19 +326,19 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
     // Handle submit action in confirm transaction dialog
     const handleConfirmTransactions = async () => {
         if (!linkId && !intentCreate?.id) return;
-        /*TODO: Temporary hold off the Confirm feature */
+
         console.log("Call confirm");
-        // try {
-        //     if (linkData?.intent_create?.state === INTENT_STATE.SUCCESS) {
-        //         await handleUpdateLinkToActive();
-        //     } else if (linkData?.intent_create?.state === INTENT_STATE.FAIL) {
-        //         handleRetryTransactions();
-        //     } else {
-        //         await startTransaction();
-        //     }
-        // } catch (err) {
-        //     console.log(err);
-        // }
+        try {
+            if (linkData?.intent_create?.state === INTENT_STATE.SUCCESS) {
+                await handleUpdateLinkToActive();
+            } else if (linkData?.intent_create?.state === INTENT_STATE.FAIL) {
+                handleRetryTransactions();
+            } else {
+                await startTransaction();
+            }
+        } catch (err) {
+            console.error(err);
+        }
     };
 
     const handleBackstep = async () => {

--- a/src/cashier_frontend/src/services/link.service.ts
+++ b/src/cashier_frontend/src/services/link.service.ts
@@ -89,21 +89,9 @@ class LinkService {
         return false;
     }
 
-    /* TODO: This createAction should return ActionModel */
-    async createAction(input: CreateIntentInput): Promise<ActionModel> {
-        const action = generateMockAction();
-        const response = parseResultResponse(await this.actor.create_intent(input));
-        return action;
-    }
-
-    /*TODO: Consider to remove this function, in case we do not need anymore*/
-    async getConsentMessage(input: GetConsentMessageInput): Promise<CreateIntentConsentModel> {
-        const response = parseResultResponse(await this.actor.get_consent_message(input));
-        return {
-            fee: response.fee,
-            receive: response.receive.map((receive) => mapReceiveModel(receive)),
-            send: response.send,
-        };
+    async createAction(): Promise<ActionModel> {
+        //const response = parseResultResponse(await this.actor.create_intent(input));
+        return generateMockAction();
     }
 }
 

--- a/src/cashier_frontend/src/services/types/enum.ts
+++ b/src/cashier_frontend/src/services/types/enum.ts
@@ -64,8 +64,9 @@ export enum CHAIN {
 }
 
 export enum TASK {
-    TRANSFER_TO_LINK_VAULT = "TransferToLinkVault",
-    TRANSFER_TO_LINK_TRESURY = "TransferToLinkTresury",
+    TRANSFER_WALLET_TO_TREASURY = "transfer_wallet_to_treasury",
+    TRANSFER_WALLET_TO_LINK = "transfer_wallet_to_link",
+    TRANSFER_LINK_TO_WALLET = "transfer_link_to_wallet",
 }
 
 export enum ACTION_TYPE {

--- a/src/cashier_frontend/src/services/types/mapper/intent.service.mapper.ts
+++ b/src/cashier_frontend/src/services/types/mapper/intent.service.mapper.ts
@@ -1,6 +1,7 @@
 import { AssetModel } from "@/components/transaction-item";
 import { Receive } from "../../../../../declarations/cashier_backend/cashier_backend.did";
 import { FeeModel, ReceiveModel, TransactionModel } from "../intent.service.types";
+import { IntentModel } from "@/services/types/refractor.intent.service.types";
 
 export const mapReceiveModel = (fee: Receive): ReceiveModel => {
     return {
@@ -40,5 +41,20 @@ export const toCanisterCallRequest = (tx: TransactionModel) => {
         canisterId: tx.canister_id,
         method: tx.method,
         arg: tx.arg,
+    };
+};
+
+export const mapIntentModelToAssetModel = (
+    intent: IntentModel | undefined,
+    transactions: TransactionModel[][] | undefined,
+) => {
+    if (!intent) {
+        return undefined;
+    }
+    return {
+        address: intent.asset.address,
+        amount: intent.amount,
+        chain: intent.asset.chain,
+        transaction: getTransactionMapWithTheFeeModel(intent.asset.address, transactions),
     };
 };

--- a/src/cashier_frontend/src/services/types/mapper/link.service.mapper.ts
+++ b/src/cashier_frontend/src/services/types/mapper/link.service.mapper.ts
@@ -31,7 +31,7 @@ export const generateMockAction = (): ActionModel => {
                 id: "1111",
                 task: TASK.TRANSFER_WALLET_TO_LINK,
                 chain: CHAIN.IC,
-                state: INTENT_STATE.CREATED,
+                state: INTENT_STATE.SUCCESS,
                 from: {
                     address: "36nrw-cqcch-ea3si-53d3r-d4bep-vcvpf-jcuq7-dgaxh-bk3ss-4plti-5qe",
                     chain: CHAIN.IC,

--- a/src/cashier_frontend/src/services/types/mapper/link.service.mapper.ts
+++ b/src/cashier_frontend/src/services/types/mapper/link.service.mapper.ts
@@ -29,7 +29,7 @@ export const generateMockAction = (): ActionModel => {
         intents: [
             {
                 id: "1111",
-                task: TASK.TRANSFER_TO_LINK_VAULT,
+                task: TASK.TRANSFER_WALLET_TO_LINK,
                 chain: CHAIN.IC,
                 state: INTENT_STATE.CREATED,
                 from: {
@@ -71,7 +71,7 @@ export const generateMockAction = (): ActionModel => {
             },
             {
                 id: "222",
-                task: TASK.TRANSFER_TO_LINK_TRESURY,
+                task: TASK.TRANSFER_WALLET_TO_TREASURY,
                 chain: CHAIN.IC,
                 state: INTENT_STATE.SUCCESS,
                 from: {
@@ -83,8 +83,8 @@ export const generateMockAction = (): ActionModel => {
                     chain: CHAIN.IC,
                 },
                 asset: {
-                    address: "",
-                    chain: "",
+                    address: "x5qut-viaaa-aaaar-qajda-cai",
+                    chain: "IC",
                 },
                 amount: 1000000n,
                 transactions: [
@@ -197,7 +197,6 @@ export const MapLinkToLinkDetailModel = (link: Link): LinkDetailModel => {
 export const MapLinkDetailModel = async (linkObj: GetLinkResp): Promise<LinkModel> => {
     const { intent, link } = linkObj;
     return {
-        /*TODO: Temporarily mock the return data for Action*/
         action: generateMockAction(),
         intent_create: fromNullable(intent),
         link: {

--- a/src/cashier_frontend/src/services/types/refractor.transaction.service.types.ts
+++ b/src/cashier_frontend/src/services/types/refractor.transaction.service.types.ts
@@ -1,9 +1,9 @@
-import { IC_TRANSACTION_PROTOCAL, TRANSACTION_STATE, Wallet } from "./enum";
+import { IC_TRANSACTION_PROTOCAL, TRANSACTION_STATE, WALLET } from "./enum";
 import { AssetModel, WalletModel } from "./refractor.intent.service.types";
 
 export type TransactionModel = {
     id: string;
-    wallet: Wallet;
+    wallet: WALLET;
     protocol: IC_TRANSACTION_PROTOCAL;
     from: WalletModel;
     to: WalletModel;


### PR DESCRIPTION
After received the response from the link for the call create link action, 
- Confirm that the intent in Created state, render the page accrodingly
- The button need to switch from "create" to "confirm"

After received the response from the link for the call execute action
- If the client confirm the the intent in Processing/Timeout state, render the loading
- If the client confirm the the intent in Succes state, render the success
- If the client confirm the the intent in Fail state, render the fail
- If the action status is Proccesing, show the "In progress" button
- If the action status is Fail, show the "Retry" button and fail banner
- If the action status is Success, show the continue button and success banner