### PR TITLE
FE - Integrate confirm action

### DIFF
--- a/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.hooks.ts
+++ b/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.hooks.ts
@@ -1,4 +1,4 @@
-import { INTENT_STATE, TASK } from "@/services/types/enum";
+import { ACTION_STATE, INTENT_STATE, TASK } from "@/services/types/enum";
 import { IntentModel } from "@/services/types/intent.service.types";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -24,14 +24,13 @@ export const useConfirmButtonState = (intentState: string | undefined) => {
 
     const mapIntentStateToButtonText = () => {
         switch (intentState) {
-            case INTENT_STATE.CREATED:
+            case ACTION_STATE.CREATED:
                 return t("transaction.confirm_popup.confirm_button");
-            case INTENT_STATE.PROCESSING:
-            case INTENT_STATE.TIMEOUT:
+            case ACTION_STATE.PROCESSING:
                 return t("transaction.confirm_popup.inprogress_button");
-            case INTENT_STATE.FAIL:
+            case ACTION_STATE.FAIL:
                 return t("retry");
-            case INTENT_STATE.SUCCESS:
+            case ACTION_STATE.SUCCESS:
                 return t("continue");
             default:
                 return t("transaction.confirm_popup.confirm_button");
@@ -40,12 +39,11 @@ export const useConfirmButtonState = (intentState: string | undefined) => {
 
     const mapIntentStateToButtonDisabled = () => {
         switch (intentState) {
-            case INTENT_STATE.CREATED:
-            case INTENT_STATE.SUCCESS:
-            case INTENT_STATE.FAIL:
+            case ACTION_STATE.CREATED:
+            case ACTION_STATE.SUCCESS:
+            case ACTION_STATE.FAIL:
                 return false;
-            case INTENT_STATE.PROCESSING:
-            case INTENT_STATE.TIMEOUT:
+            case ACTION_STATE.PROCESSING:
                 return true;
             default:
                 return true;

--- a/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.hooks.ts
+++ b/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.hooks.ts
@@ -22,7 +22,7 @@ export const useCashierFeeIntents = (intents: IntentModel[] | undefined) => {
 export const useConfirmButtonState = (intentState: string | undefined) => {
     const { t } = useTranslation();
 
-    const mapIntentStateToButtonText = () => {
+    const mapActionStateToButtonText = () => {
         switch (intentState) {
             case ACTION_STATE.CREATED:
                 return t("transaction.confirm_popup.confirm_button");
@@ -37,7 +37,7 @@ export const useConfirmButtonState = (intentState: string | undefined) => {
         }
     };
 
-    const mapIntentStateToButtonDisabled = () => {
+    const mapActionStateToButtonDisabled = () => {
         switch (intentState) {
             case ACTION_STATE.CREATED:
             case ACTION_STATE.SUCCESS:
@@ -51,7 +51,7 @@ export const useConfirmButtonState = (intentState: string | undefined) => {
     };
 
     return {
-        disabled: mapIntentStateToButtonDisabled(),
-        text: mapIntentStateToButtonText(),
+        disabled: mapActionStateToButtonDisabled(),
+        text: mapActionStateToButtonText(),
     };
 };

--- a/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx
+++ b/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx
@@ -1,7 +1,7 @@
 import { TransactionModel } from "@/services/types/intent.service.types";
 import { LinkModel } from "@/services/types/link.service.types";
 import { ActionModel } from "@/services/types/action.service.types";
-import { FC } from "react";
+import { FC, useEffect, useState } from "react";
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from "@/components/ui/drawer";
 import { useTranslation } from "react-i18next";
 import { IoIosClose } from "react-icons/io";
@@ -42,6 +42,17 @@ export const ConfirmationDrawer: FC<ConfirmationDrawerProps> = ({
     const primaryIntents = usePrimaryIntents(data?.action?.intents);
     const cashierFeeIntents = useCashierFeeIntents(data?.action?.intents);
     const { disabled, text } = useConfirmButtonState(data?.action?.state);
+    const [isDisabled, setIsDisabled] = useState(disabled);
+
+    const onClickSubmit = () => {
+        setIsDisabled(true);
+        onConfirm();
+    };
+
+    useEffect(() => {
+        setIsDisabled(disabled);
+    }, [disabled]);
+
     return (
         <Drawer open={open}>
             <DrawerContent className="max-w-[400px] mx-auto p-3">
@@ -70,7 +81,7 @@ export const ConfirmationDrawer: FC<ConfirmationDrawerProps> = ({
 
                         <ConfirmationPopupLegalSection />
 
-                        <Button disabled={disabled} onClick={onConfirm}>
+                        <Button disabled={isDisabled} onClick={onClickSubmit}>
                             {text}
                         </Button>
                     </>

--- a/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx
+++ b/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx
@@ -56,22 +56,21 @@ export const ConfirmationDrawer: FC<ConfirmationDrawerProps> = ({
     return (
         <Drawer open={open}>
             <DrawerContent className="max-w-[400px] mx-auto p-3">
+                <DrawerHeader>
+                    <DrawerTitle className="flex justify-center items-center">
+                        <div className="text-center w-[100%]">
+                            {t("transaction.confirm_popup.title")}
+                        </div>
+
+                        <IoIosClose
+                            onClick={onClose}
+                            className="ml-auto cursor-pointer"
+                            size={32}
+                        />
+                    </DrawerTitle>
+                </DrawerHeader>
                 {data ? (
                     <>
-                        <DrawerHeader>
-                            <DrawerTitle className="flex justify-center items-center">
-                                <div className="text-center w-[100%]">
-                                    {t("transaction.confirm_popup.title")}
-                                </div>
-
-                                <IoIosClose
-                                    onClick={onClose}
-                                    className="ml-auto cursor-pointer"
-                                    size={32}
-                                />
-                            </DrawerTitle>
-                        </DrawerHeader>
-
                         <ConfirmationPopupAssetsSection
                             intents={primaryIntents}
                             onInfoClick={onInfoClick}

--- a/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx
+++ b/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx
@@ -43,15 +43,18 @@ export const ConfirmationDrawer: FC<ConfirmationDrawerProps> = ({
     const cashierFeeIntents = useCashierFeeIntents(data?.action?.intents);
     const { disabled, text } = useConfirmButtonState(data?.action?.state);
     const [isDisabled, setIsDisabled] = useState(disabled);
+    const [buttonText, setButtonText] = useState(text);
 
     const onClickSubmit = () => {
         setIsDisabled(true);
+        setButtonText(t("transaction.confirm_popup.processing"));
         onConfirm();
     };
 
     useEffect(() => {
         setIsDisabled(disabled);
-    }, [disabled]);
+        setButtonText(text);
+    }, [disabled, text]);
 
     return (
         <Drawer open={open}>
@@ -81,7 +84,7 @@ export const ConfirmationDrawer: FC<ConfirmationDrawerProps> = ({
                         <ConfirmationPopupLegalSection />
 
                         <Button disabled={isDisabled} onClick={onClickSubmit}>
-                            {text}
+                            {buttonText}
                         </Button>
                     </>
                 ) : (

--- a/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx
+++ b/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx
@@ -14,6 +14,7 @@ import {
     useConfirmButtonState,
     usePrimaryIntents,
 } from "./confirmation-drawer.hooks";
+import { ConfirmationPopupSkeleton } from "./confirmation-drawer-skeleton";
 
 export type ConfirmTransactionModel = {
     linkName?: string;
@@ -40,37 +41,42 @@ export const ConfirmationDrawer: FC<ConfirmationDrawerProps> = ({
     const { t } = useTranslation();
     const primaryIntents = usePrimaryIntents(data?.action?.intents);
     const cashierFeeIntents = useCashierFeeIntents(data?.action?.intents);
-    const { disabled, text } = useConfirmButtonState(data?.linkData.intent_create?.state);
-
+    const { disabled, text } = useConfirmButtonState(data?.action?.state);
     return (
         <Drawer open={open}>
             <DrawerContent className="max-w-[400px] mx-auto p-3">
-                <DrawerHeader>
-                    <DrawerTitle className="flex justify-center items-center">
-                        <div className="text-center w-[100%]">
-                            {t("transaction.confirm_popup.title")}
-                        </div>
+                {data ? (
+                    <>
+                        <DrawerHeader>
+                            <DrawerTitle className="flex justify-center items-center">
+                                <div className="text-center w-[100%]">
+                                    {t("transaction.confirm_popup.title")}
+                                </div>
 
-                        <IoIosClose
-                            onClick={onClose}
-                            className="ml-auto cursor-pointer"
-                            size={32}
+                                <IoIosClose
+                                    onClick={onClose}
+                                    className="ml-auto cursor-pointer"
+                                    size={32}
+                                />
+                            </DrawerTitle>
+                        </DrawerHeader>
+
+                        <ConfirmationPopupAssetsSection
+                            intents={primaryIntents}
+                            onInfoClick={onInfoClick}
                         />
-                    </DrawerTitle>
-                </DrawerHeader>
 
-                <ConfirmationPopupAssetsSection
-                    intents={primaryIntents}
-                    onInfoClick={onInfoClick}
-                />
+                        <ConfirmationPopupFeesSection intents={cashierFeeIntents} />
 
-                <ConfirmationPopupFeesSection intents={cashierFeeIntents} />
+                        <ConfirmationPopupLegalSection />
 
-                <ConfirmationPopupLegalSection />
-
-                <Button disabled={disabled} onClick={onConfirm}>
-                    {text}
-                </Button>
+                        <Button disabled={disabled} onClick={onConfirm}>
+                            {text}
+                        </Button>
+                    </>
+                ) : (
+                    <ConfirmationPopupSkeleton />
+                )}
             </DrawerContent>
         </Drawer>
     );

--- a/src/cashier_frontend/src/components/link-details/tip-link-asset-form.tsx
+++ b/src/cashier_frontend/src/components/link-details/tip-link-asset-form.tsx
@@ -49,8 +49,6 @@ export const TipLinkAssetForm: FC<TipLinkAssetFormProps> = ({ onSubmit, defaultV
     const handleSetAmount = useHandleSetAmount(form);
     const handleSetTokenAddress = useHandleSetTokenAddress(form, () => setShowAssetDrawer(false));
 
-    console.log(form.formState.errors);
-
     return (
         <div className="w-full">
             {isLoadingAssets ? (

--- a/src/cashier_frontend/src/components/link-preview/link-preview-cashier-fee-section.tsx
+++ b/src/cashier_frontend/src/components/link-preview/link-preview-cashier-fee-section.tsx
@@ -15,7 +15,9 @@ export const LinkPreviewCashierFeeSection: FC<LinkPreviewCashierFeeSectionProps>
     onInfoClick,
 }) => {
     const { t } = useTranslation();
-
+    if (intents.length === 0) {
+        return null;
+    }
     return (
         <>
             <div className="flex justify-between items-center">

--- a/src/cashier_frontend/src/components/multi-step-form.tsx
+++ b/src/cashier_frontend/src/components/multi-step-form.tsx
@@ -1,7 +1,7 @@
 import { Children, ReactElement, ReactNode, useState } from "react";
 import { ChevronLeftIcon } from "@radix-ui/react-icons";
-import { IntentCreateModel } from "@/services/types/intent.service.types";
 import { LINK_TYPE } from "@/services/types/enum";
+import { ActionModel } from "@/services/types/action.service.types";
 
 /**
  * - V1: type for handle submit
@@ -28,7 +28,7 @@ interface MultiStepFormProps<V1 extends object, V2 extends object> {
     handleBack?: () => void;
     handleChange: (value: V2) => void;
     isDisabled: boolean;
-    actionCreate: IntentCreateModel | undefined;
+    action: ActionModel | undefined;
 }
 
 /**
@@ -55,13 +55,13 @@ export default function MultiStepForm<V1 extends object, V2 extends object>({
     handleBack,
     handleChange,
     isDisabled,
-    actionCreate,
+    action,
 }: MultiStepFormProps<V1, V2>) {
     const partialForms = Children.toArray(children) as ReactElement<ItemProp<V1, V2>>[];
     const [currentStep, setCurrentStep] = useState(initialStep);
 
     const handleClickBack = async () => {
-        if ((!currentStep || actionCreate) && handleBack) {
+        if ((!currentStep || action) && handleBack) {
             handleBack();
         } else {
             await handleBackStep();

--- a/src/cashier_frontend/src/components/test-form/user-wallet-test-form.tsx
+++ b/src/cashier_frontend/src/components/test-form/user-wallet-test-form.tsx
@@ -35,7 +35,6 @@ export function UserWalletTestForm(props: TestFormProps) {
                 walletAddress,
             );
             if (fetchedBalance) {
-                console.log("🚀 ~ handleSubmitForm ~ fetchedBalance:", fetchedBalance);
                 const parsedAmount = await TokenUtilService.getHumanReadableAmount(
                     fetchedBalance,
                     canisterId,

--- a/src/cashier_frontend/src/locales/en.json
+++ b/src/cashier_frontend/src/locales/en.json
@@ -67,7 +67,8 @@
             "transaction_failed": "Transaction failed",
             "transaction_failed_message": "Retry failed transaction",
             "transaction_success": "Transaction success",
-            "transaction_success_message": "",
+            "transaction_success_message": "Continue to active link",
+            "processing": "Processing...",
             "legal_text": "By confirming you agree to execute the transaction above and agree to the terms of service",
             "info": {
                 "button_text": "Close"

--- a/src/cashier_frontend/src/pages/edit/[id]/index.tsx
+++ b/src/cashier_frontend/src/pages/edit/[id]/index.tsx
@@ -30,6 +30,7 @@ import { getCashierError } from "@/services/errorProcess.service";
 import { ActionModel } from "@/services/types/action.service.types";
 import { useLinkDataQuery } from "@/hooks/useLinkDataQuery";
 import { LINK_TEMPLATE_DESCRIPTION_MESSAGE } from "@/constants/message";
+import { Icrc112RequestModel } from "@/services/types/transaction.service.types";
 
 const STEP_LINK_STATE_ORDER = [
     LINK_STATE.CHOOSE_TEMPLATE,
@@ -224,7 +225,7 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
     };
 
     const callExecute = async (
-        transactions: TransactionModel[][] | undefined,
+        transactions: Icrc112RequestModel[][] | undefined,
         identity: Identity | undefined,
     ) => {
         if (!identity) return;
@@ -233,10 +234,7 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
         }
         try {
             const signerService = new SignerService(identity);
-            const icrcxRequests = transactions.map((subTrans) => {
-                return subTrans.map((tx) => toCanisterCallRequest(tx));
-            });
-            const res = await signerService.icrcxExecute(icrcxRequests);
+            const res = await signerService.icrcxExecute(transactions);
             return res;
         } catch (err) {
             console.log(err);
@@ -278,6 +276,12 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
             };
             setTransactionConfirmModel(transactionConfirmObj);
         }
+
+        // Calling execute after process_action
+        // const icrc112ExecuteRes = await callExecute(action.icrc112Requests, identity);
+        // console.log("🚀 ~ startTransaction ~ icrc112ExecuteRes:", icrc112ExecuteRes);
+
+        // TODO: Remove after demo
         setTimeout(async () => {
             console.log("Calling update action");
             const inputModel: UpdateActionInputModel = {

--- a/src/cashier_frontend/src/pages/edit/[id]/index.tsx
+++ b/src/cashier_frontend/src/pages/edit/[id]/index.tsx
@@ -6,7 +6,10 @@ import MultiStepForm from "@/components/multi-step-form";
 import { useTranslation } from "react-i18next";
 import LinkPreview from "./LinkPreview";
 import { useIdentity } from "@nfid/identitykit/react";
-import LinkService, { CreateActionInputModel } from "@/services/link.service";
+import LinkService, {
+    CreateActionInputModel,
+    UpdateActionInputModel,
+} from "@/services/link.service";
 import { useQueryClient } from "@tanstack/react-query";
 import { UpdateLinkParams, useUpdateLink } from "@/hooks/linkHooks";
 import { LinkDetailModel, State, Template } from "@/services/types/link.service.types";
@@ -264,34 +267,28 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
         };
         const linkService = new LinkService(identity);
         const action = await linkService.processAction(input);
-        console.log("🚀 ~ startTransaction ~ action:", action);
-
-        // TODO: Temporary comment out these lines and will update later
-        // if (confirmItemResult?.transactions) {
-        //     // Change transaction status to processing
-        //     setIntentCreate(
-        //         (prev) =>
-        //             ({
-        //                 ...prev,
-        //                 transactions: confirmItemResult?.transactions,
-        //             }) as IntentCreateModel,
-        //     );
-        //     setTransactionConfirmModel(
-        //         (prevModel) =>
-        //             ({
-        //                 ...prevModel,
-        //                 transactions: confirmItemResult?.transactions,
-        //             }) as ConfirmTransactionModel,
-        //     );
-        //     console.log("Call canister transfer");
-        //     const result = await callExecute(intentCreate?.transactions, identity);
-        //     if (result) {
-        //         console.log(
-        //             "Canister service call complete. Now re-fetch the link data to get the intent.",
-        //         );
-        //         refetch();
-        //     }
-        // }
+        console.log("🚀 ~ Action response after calling process_action ~ action:", action);
+        if (action) {
+            setLinkAction(action);
+            const transactionConfirmObj: ConfirmTransactionModel = {
+                linkName: formData.title ?? "",
+                linkData: linkData!,
+                transactions: intentCreate?.transactions,
+                action: action,
+            };
+            setTransactionConfirmModel(transactionConfirmObj);
+        }
+        setTimeout(async () => {
+            console.log("Calling update action");
+            const inputModel: UpdateActionInputModel = {
+                actionId: action.id,
+                linkId: linkId ?? "",
+                external: true,
+            };
+            const linkService = new LinkService(identity);
+            const actionRes = await linkService.updateAction(inputModel);
+            console.log("🚀 ~ setTimeout ~ actionRes:", actionRes);
+        }, 18000);
     };
 
     const handleRetryTransactions = () => {

--- a/src/cashier_frontend/src/pages/edit/[id]/index.tsx
+++ b/src/cashier_frontend/src/pages/edit/[id]/index.tsx
@@ -234,17 +234,19 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
         transactions: Icrc112RequestModel[][] | undefined,
         identity: Identity | undefined,
     ) => {
-        if (!identity) return;
-        if (!transactions || transactions.length === 0) {
-            return;
-        }
-        try {
-            const signerService = new SignerService(identity);
-            const res = await signerService.icrcxExecute(transactions);
-            return res;
-        } catch (err) {
-            console.log(err);
-        }
+        //TOODO: Remove after demo
+        console.log("CALLING MOCK EXECUTE ICRC-112");
+        // if (!identity) return;
+        // if (!transactions || transactions.length === 0) {
+        //     return;
+        // }
+        // try {
+        //     const signerService = new SignerService(identity);
+        //     const res = await signerService.icrcxExecute(transactions);
+        //     return res;
+        // } catch (err) {
+        //     console.log(err);
+        // }
     };
 
     const handleChange = (values: Partial<LinkDetailModel>) => {
@@ -252,7 +254,6 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
     };
 
     const handleUpdateLinkToActive = async () => {
-        console.log("Update link to active");
         const updateLinkParams: UpdateLinkParams = {
             linkId: linkId ?? "",
             linkModel: {
@@ -285,12 +286,11 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
         }
 
         // Calling execute after process_action
-        // const icrc112ExecuteRes = await callExecute(action.icrc112Requests, identity);
-        // console.log("🚀 ~ startTransaction ~ icrc112ExecuteRes:", icrc112ExecuteRes);
+        const icrc112ExecuteRes = await callExecute(action.icrc112Requests, identity);
 
         // TODO: Remove after demo
         setTimeout(async () => {
-            console.log("Calling update action");
+            console.log("CALLING UPDATE ACTION");
             const inputModel: UpdateActionInputModel = {
                 actionId: action.id,
                 linkId: linkId ?? "",
@@ -308,12 +308,8 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
                 };
                 setTransactionConfirmModel(transactionConfirmObj);
             }
-            console.log("🚀 ~ setTimeout ~ actionRes:", actionRes);
+            console.log("🚀 ~ Response as Action from update_action: ", actionRes);
         }, 15000);
-    };
-
-    const handleRetryTransactions = () => {
-        console.log("Retry");
     };
 
     // Handle submit action in confirm transaction dialog
@@ -321,11 +317,11 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
         if (!linkId) return;
         try {
             if (linkAction?.state === ACTION_STATE.SUCCESS) {
+                console.log("CLICKED SUBMIT BUTTON");
+                console.log("UPDATING LINK TO ACTIVE STATE...");
                 await handleUpdateLinkToActive();
-            } else if (linkAction?.state === ACTION_STATE.FAIL) {
-                handleRetryTransactions();
             } else {
-                console.log("Confirm action");
+                console.log("CLICKED SUBMIT BUTTON");
                 await startTransaction();
             }
         } catch (err) {

--- a/src/cashier_frontend/src/pages/edit/[id]/index.tsx
+++ b/src/cashier_frontend/src/pages/edit/[id]/index.tsx
@@ -19,7 +19,13 @@ import { useResponsive } from "@/hooks/responsive-hook";
 import { getResponsiveClassname } from "@/utils";
 import { responsiveMapper } from "./index_responsive";
 import { z } from "zod";
-import { ACTION_TYPE, INTENT_STATE, LINK_STATE, LINK_TYPE } from "@/services/types/enum";
+import {
+    ACTION_STATE,
+    ACTION_TYPE,
+    INTENT_STATE,
+    LINK_STATE,
+    LINK_TYPE,
+} from "@/services/types/enum";
 import { IntentCreateModel, TransactionModel } from "@/services/types/intent.service.types";
 import IntentService from "@/services/intent.service";
 import SignerService from "@/services/signer.service";
@@ -246,6 +252,7 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
     };
 
     const handleUpdateLinkToActive = async () => {
+        console.log("Update link to active");
         const updateLinkParams: UpdateLinkParams = {
             linkId: linkId ?? "",
             linkModel: {
@@ -291,8 +298,18 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
             };
             const linkService = new LinkService(identity);
             const actionRes = await linkService.updateAction(inputModel);
+            if (actionRes) {
+                setLinkAction(actionRes);
+                const transactionConfirmObj: ConfirmTransactionModel = {
+                    linkName: formData.title ?? "",
+                    linkData: linkData!,
+                    transactions: intentCreate?.transactions,
+                    action: actionRes,
+                };
+                setTransactionConfirmModel(transactionConfirmObj);
+            }
             console.log("🚀 ~ setTimeout ~ actionRes:", actionRes);
-        }, 18000);
+        }, 15000);
     };
 
     const handleRetryTransactions = () => {
@@ -301,11 +318,11 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
 
     // Handle submit action in confirm transaction dialog
     const handleAction = async () => {
-        if (!linkId && !intentCreate?.id) return;
+        if (!linkId) return;
         try {
-            if (linkData?.intent_create?.state === INTENT_STATE.SUCCESS) {
+            if (linkAction?.state === ACTION_STATE.SUCCESS) {
                 await handleUpdateLinkToActive();
-            } else if (linkData?.intent_create?.state === INTENT_STATE.FAIL) {
+            } else if (linkAction?.state === ACTION_STATE.FAIL) {
                 handleRetryTransactions();
             } else {
                 console.log("Confirm action");

--- a/src/cashier_frontend/src/pages/edit/[id]/index.tsx
+++ b/src/cashier_frontend/src/pages/edit/[id]/index.tsx
@@ -236,17 +236,17 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
     ) => {
         //TOODO: Remove after demo
         console.log("CALLING MOCK EXECUTE ICRC-112");
-        // if (!identity) return;
-        // if (!transactions || transactions.length === 0) {
-        //     return;
-        // }
-        // try {
-        //     const signerService = new SignerService(identity);
-        //     const res = await signerService.icrcxExecute(transactions);
-        //     return res;
-        // } catch (err) {
-        //     console.log(err);
-        // }
+        if (!identity) return;
+        if (!transactions || transactions.length === 0) {
+            return;
+        }
+        try {
+            const signerService = new SignerService(identity);
+            const res = await signerService.icrcxExecute(transactions);
+            return res;
+        } catch (err) {
+            console.log(err);
+        }
     };
 
     const handleChange = (values: Partial<LinkDetailModel>) => {
@@ -258,6 +258,7 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
             linkId: linkId ?? "",
             linkModel: {
                 ...formData,
+                description: "none",
             },
             isContinue: true,
         };
@@ -287,6 +288,7 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
 
         // Calling execute after process_action
         const icrc112ExecuteRes = await callExecute(action.icrc112Requests, identity);
+        console.log("MOCK RESPONSE FROM EXECUTING ICRC-112: ", icrc112ExecuteRes);
 
         // TODO: Remove after demo
         setTimeout(async () => {
@@ -307,6 +309,21 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
                     action: actionRes,
                 };
                 setTransactionConfirmModel(transactionConfirmObj);
+                const toastData = {
+                    title:
+                        actionRes.state === ACTION_STATE.SUCCESS
+                            ? t("transaction.confirm_popup.transaction_success")
+                            : t("transaction.confirm_popup.transaction_failed"),
+                    description:
+                        actionRes.state === ACTION_STATE.SUCCESS
+                            ? t("transaction.confirm_popup.transaction_success_message")
+                            : t("transaction.confirm_popup.transaction_failed_message"),
+                    variant:
+                        actionRes.state === ACTION_STATE.SUCCESS
+                            ? ("default" as const)
+                            : ("error" as const),
+                };
+                showToast(toastData.title, toastData.description, toastData.variant);
             }
             console.log("🚀 ~ Response as Action from update_action: ", actionRes);
         }, 15000);

--- a/src/cashier_frontend/src/pages/edit/[id]/index.tsx
+++ b/src/cashier_frontend/src/pages/edit/[id]/index.tsx
@@ -287,8 +287,8 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
         }
 
         // Calling execute after process_action
-        const icrc112ExecuteRes = await callExecute(action.icrc112Requests, identity);
-        console.log("MOCK RESPONSE FROM EXECUTING ICRC-112: ", icrc112ExecuteRes);
+        //const icrc112ExecuteRes = await callExecute(action.icrc112Requests, identity);
+        //console.log("MOCK RESPONSE FROM EXECUTING ICRC-112: ", icrc112ExecuteRes);
 
         // TODO: Remove after demo
         setTimeout(async () => {
@@ -309,21 +309,26 @@ export default function LinkPage({ initialStep = 0 }: { initialStep?: number }) 
                     action: actionRes,
                 };
                 setTransactionConfirmModel(transactionConfirmObj);
-                const toastData = {
-                    title:
-                        actionRes.state === ACTION_STATE.SUCCESS
-                            ? t("transaction.confirm_popup.transaction_success")
-                            : t("transaction.confirm_popup.transaction_failed"),
-                    description:
-                        actionRes.state === ACTION_STATE.SUCCESS
-                            ? t("transaction.confirm_popup.transaction_success_message")
-                            : t("transaction.confirm_popup.transaction_failed_message"),
-                    variant:
-                        actionRes.state === ACTION_STATE.SUCCESS
-                            ? ("default" as const)
-                            : ("error" as const),
-                };
-                showToast(toastData.title, toastData.description, toastData.variant);
+                if (
+                    actionRes.state === ACTION_STATE.SUCCESS ||
+                    actionRes.state === ACTION_STATE.FAIL
+                ) {
+                    const toastData = {
+                        title:
+                            actionRes.state === ACTION_STATE.SUCCESS
+                                ? t("transaction.confirm_popup.transaction_success")
+                                : t("transaction.confirm_popup.transaction_failed"),
+                        description:
+                            actionRes.state === ACTION_STATE.SUCCESS
+                                ? t("transaction.confirm_popup.transaction_success_message")
+                                : t("transaction.confirm_popup.transaction_failed_message"),
+                        variant:
+                            actionRes.state === ACTION_STATE.SUCCESS
+                                ? ("default" as const)
+                                : ("error" as const),
+                    };
+                    showToast(toastData.title, toastData.description, toastData.variant);
+                }
             }
             console.log("🚀 ~ Response as Action from update_action: ", actionRes);
         }, 15000);

--- a/src/cashier_frontend/src/services/link.service.ts
+++ b/src/cashier_frontend/src/services/link.service.ts
@@ -26,6 +26,7 @@ interface ReponseLinksModel {
 export interface CreateActionInputModel {
     linkId: string;
     actionType: string;
+    actionId?: string;
 }
 
 class LinkService {
@@ -89,9 +90,9 @@ class LinkService {
         return false;
     }
 
-    async createAction(input: CreateActionInputModel): Promise<ActionModel> {
+    async processAction(input: CreateActionInputModel): Promise<ActionModel> {
         const inputModel: ProcessActionInput = {
-            action_id: "",
+            action_id: input.actionId ?? "",
             link_id: input.linkId,
             action_type: input.actionType,
             params: [],

--- a/src/cashier_frontend/src/services/link.service.ts
+++ b/src/cashier_frontend/src/services/link.service.ts
@@ -5,6 +5,7 @@ import {
     CreateLinkInput,
     LinkDto,
     ProcessActionInput,
+    UpdateActionInput,
 } from "../../../declarations/cashier_backend/cashier_backend.did";
 import { HttpAgent, Identity } from "@dfinity/agent";
 import { BACKEND_CANISTER_ID } from "@/const";
@@ -27,6 +28,12 @@ export interface CreateActionInputModel {
     linkId: string;
     actionType: string;
     actionId?: string;
+}
+
+export interface UpdateActionInputModel {
+    actionId: string;
+    linkId: string;
+    external: boolean;
 }
 
 class LinkService {
@@ -100,6 +107,18 @@ class LinkService {
         const response = parseResultResponse(await this.actor.process_action(inputModel));
         const action = mapActionModel(response);
         return action;
+    }
+
+    async updateAction(inputModel: UpdateActionInputModel) {
+        const input: UpdateActionInput = {
+            action_id: inputModel.actionId,
+            link_id: inputModel.linkId,
+            external: inputModel.external ?? true,
+        };
+        const response = parseResultResponse(await this.actor.update_action(input));
+        const action = mapActionModel(response);
+        return action;
+        return response;
     }
 }
 

--- a/src/cashier_frontend/src/services/link.service.ts
+++ b/src/cashier_frontend/src/services/link.service.ts
@@ -118,7 +118,6 @@ class LinkService {
         const response = parseResultResponse(await this.actor.update_action(input));
         const action = mapActionModel(response);
         return action;
-        return response;
     }
 }
 

--- a/src/cashier_frontend/src/services/types/action.service.types.ts
+++ b/src/cashier_frontend/src/services/types/action.service.types.ts
@@ -1,9 +1,12 @@
-import { ACTION_TYPE } from "./enum";
+import { ACTION_STATE, ACTION_TYPE } from "./enum";
 import { IntentModel } from "./intent.service.types";
+import { Icrc112RequestModel } from "./transaction.service.types";
 
 export type ActionModel = {
     id: string;
     creator: string;
     type: ACTION_TYPE;
+    state: ACTION_STATE;
     intents: IntentModel[];
+    icrc112Requests?: Icrc112RequestModel[][];
 };

--- a/src/cashier_frontend/src/services/types/enum.ts
+++ b/src/cashier_frontend/src/services/types/enum.ts
@@ -30,6 +30,13 @@ export enum INTENT_STATE {
     TIMEOUT = "Intent_state_timeout",
 }
 
+export enum ACTION_STATE {
+    CREATED = "Action_state_created",
+    PROCESSING = "Action_state_processing",
+    SUCCESS = "Action_state_success",
+    FAIL = "Action_state_fail",
+}
+
 export enum INTENT_TYPE {
     TRANSFER_FROM = "TransferFrom",
     TRANSFER = "Transfer",

--- a/src/cashier_frontend/src/services/types/mapper/action.service.mapper.ts
+++ b/src/cashier_frontend/src/services/types/mapper/action.service.mapper.ts
@@ -1,7 +1,9 @@
 import { ActionDto } from "../../../../../declarations/cashier_backend/cashier_backend.did";
-import { ACTION_TYPE } from "../enum";
+import { ACTION_STATE, ACTION_TYPE } from "../enum";
 import { ActionModel } from "../action.service.types";
 import { mapIntentDtoToIntentModel } from "./intent.service.mapper";
+import { mapICRC112Request } from "./transaction.service.mapper";
+import { fromNullable } from "@dfinity/utils";
 
 // Map Action from back-end to front-end model
 export const mapActionModel = (actionDTO: ActionDto | undefined): ActionModel => {
@@ -9,6 +11,7 @@ export const mapActionModel = (actionDTO: ActionDto | undefined): ActionModel =>
         return {
             id: "",
             creator: "",
+            state: ACTION_STATE.CREATED,
             type: ACTION_TYPE.CREATE_LINK,
             intents: [],
         };
@@ -19,7 +22,15 @@ export const mapActionModel = (actionDTO: ActionDto | undefined): ActionModel =>
             type: Object.values(ACTION_TYPE).includes(actionDTO.type as ACTION_TYPE)
                 ? (actionDTO.type as ACTION_TYPE)
                 : ACTION_TYPE.CREATE_LINK,
+            state: Object.values(ACTION_STATE).includes(actionDTO.state as ACTION_STATE)
+                ? (actionDTO.state as ACTION_STATE)
+                : ACTION_STATE.CREATED,
             intents: actionDTO.intents.map((intent) => mapIntentDtoToIntentModel(intent)),
+            icrc112Requests: fromNullable(actionDTO.icrc_112_requests)
+                ? fromNullable(actionDTO.icrc_112_requests)?.map((request) => {
+                      return request.map((req) => mapICRC112Request(req));
+                  })
+                : [],
         };
     }
 };

--- a/src/cashier_frontend/src/services/types/mapper/link.service.mapper.ts
+++ b/src/cashier_frontend/src/services/types/mapper/link.service.mapper.ts
@@ -6,65 +6,12 @@ import {
     UpdateLinkInput,
 } from "../../../../../declarations/cashier_backend/cashier_backend.did";
 import { LinkDetailModel, LinkModel } from "../link.service.types";
-import { ACTION_TYPE, CHAIN, INTENT_STATE, INTENT_TYPE, TASK, TEMPLATE } from "../enum";
+import { CHAIN, TEMPLATE } from "../enum";
 import { fromDefinedNullable, fromNullable } from "@dfinity/utils";
 import { TokenUtilService } from "@/services/tokenUtils.service";
-import { ActionModel } from "../action.service.types";
 import { mapActionModel } from "./action.service.mapper";
 
 const IS_USE_DEFAULT_LINK_TEMPLATE = true;
-
-export const generateMockAction = (): ActionModel => {
-    return {
-        id: "test111",
-        type: ACTION_TYPE.CREATE_LINK,
-        creator: "",
-        intents: [
-            {
-                id: "1111",
-                task: TASK.TRANSFER_WALLET_TO_LINK,
-                type: INTENT_TYPE.TRANSFER_FROM,
-                chain: CHAIN.IC,
-                state: INTENT_STATE.PROCESSING,
-                from: {
-                    address: "36nrw-cqcch-ea3si-53d3r-d4bep-vcvpf-jcuq7-dgaxh-bk3ss-4plti-5qe",
-                    chain: CHAIN.IC,
-                },
-                to: {
-                    address: "rdpcv-vctd4-hb7ni-cy5sq-kroai-ultcg-2dh2j-gqaxj-tczxw-reyry-2qe",
-                    chain: CHAIN.IC,
-                },
-                asset: {
-                    address: "x5qut-viaaa-aaaar-qajda-cai",
-                    chain: CHAIN.IC,
-                },
-                amount: 250000000n,
-                createdAt: new Date(),
-            },
-            {
-                id: "222",
-                type: INTENT_TYPE.TRANSFER,
-                task: TASK.TRANSFER_WALLET_TO_TREASURY,
-                chain: CHAIN.IC,
-                state: INTENT_STATE.SUCCESS,
-                from: {
-                    address: "36nrw-cqcch-ea3si-53d3r-d4bep-vcvpf-jcuq7-dgaxh-bk3ss-4plti-5qe",
-                    chain: CHAIN.IC,
-                },
-                to: {
-                    address: "rdpcv-vctd4-hb7ni-cy5sq-kroai-ultcg-2dh2j-gqaxj-tczxw-reyry-2qe",
-                    chain: CHAIN.IC,
-                },
-                asset: {
-                    address: "x5qut-viaaa-aaaar-qajda-cai",
-                    chain: "IC",
-                },
-                amount: 1000000n,
-                createdAt: new Date(),
-            },
-        ],
-    };
-};
 
 // Map front-end 'Link' model to back-end model
 export const MapLinkDetailModelToUpdateLinkInputModel = (

--- a/src/cashier_frontend/src/services/types/mapper/transaction.service.mapper.ts
+++ b/src/cashier_frontend/src/services/types/mapper/transaction.service.mapper.ts
@@ -1,0 +1,12 @@
+import { fromNullable } from "@dfinity/utils";
+import { Icrc112Request } from "../../../../../declarations/cashier_backend/cashier_backend.did";
+import { Icrc112RequestModel } from "../transaction.service.types";
+
+export const mapICRC112Request = (dto: Icrc112Request): Icrc112RequestModel => {
+    return {
+        arg: dto.arg,
+        method: dto.method,
+        canisterId: dto.canister_id,
+        nonce: fromNullable(dto.nonce),
+    };
+};

--- a/src/cashier_frontend/src/services/types/transaction.service.types.ts
+++ b/src/cashier_frontend/src/services/types/transaction.service.types.ts
@@ -11,3 +11,10 @@ export type TransactionModel = {
     amount: bigint;
     state: TRANSACTION_STATE;
 };
+
+export type Icrc112RequestModel = {
+    arg: string;
+    method: string;
+    canisterId: string;
+    nonce?: string;
+};


### PR DESCRIPTION
Following change(s):
- Use response as action from process_action method (instead of mock data) to display confirm transaction popup state
- Integrate process_action for handling confirm action
- Update banner display message when action is success or fail