### PR TITLE
Call update action after finish execute ICRC-112

### DIFF
--- a/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx
+++ b/src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx
@@ -73,19 +73,19 @@ export const ConfirmationDrawer: FC<ConfirmationDrawerProps> = ({
         const response = await icrc112Execute(firstUpdatedAction!.icrc112Requests);
         console.log("🚀 ~ startTransaction ~ response:", response);
 
-        // TODO: Remove after demo
-        // setTimeout(async () => {
-        //     const secondUpdatedAction = await updateAction({
-        //         actionId: action!.id,
-        //         linkId: link!.id,
-        //         external: true,
-        //     });
+        setTimeout(async () => {
+            const secondUpdatedAction = await updateAction({
+                actionId: action!.id,
+                linkId: link!.id,
+                external: true,
+            });
+            console.log("🚀 ~ startTransaction ~ secondUpdatedAction:", secondUpdatedAction);
 
-        //     if (secondUpdatedAction) {
-        //         setAction(secondUpdatedAction);
-        //         onActionResult(secondUpdatedAction);
-        //     }
-        // }, 15000);
+            if (secondUpdatedAction) {
+                setAction(secondUpdatedAction);
+                onActionResult(secondUpdatedAction);
+            }
+        }, 10000);
     };
 
     const onClickSubmit = async () => {

--- a/src/cashier_frontend/src/hooks/useLinkDataQuery.ts
+++ b/src/cashier_frontend/src/hooks/useLinkDataQuery.ts
@@ -10,6 +10,7 @@ export const useLinkDataQuery = (linkId: string | undefined) => {
         queryKey: queryKeys.links.detail(linkId, ACTION_TYPE.CREATE_LINK, identity).queryKey,
         queryFn: queryKeys.links.detail(linkId, ACTION_TYPE.CREATE_LINK, identity).queryFn,
         enabled: !!linkId && !!identity,
+        refetchOnWindowFocus: false,
     });
 
     return query;

--- a/src/cashier_frontend/src/services/link.service.ts
+++ b/src/cashier_frontend/src/services/link.service.ts
@@ -50,7 +50,7 @@ class LinkService {
             await this.actor.get_links([
                 {
                     offset: BigInt(0),
-                    limit: BigInt(10),
+                    limit: BigInt(30),
                 },
             ]),
         );


### PR DESCRIPTION
### Updates to existing functionalities:

* [`src/cashier_frontend/src/components/confirmation-drawer/confirmation-drawer.tsx`](diffhunk://#diff-e255898cd53e0e034307bb8da82793491647ebfb4427a05dac57012264e02280L76-R88): Call update action after 10s when finish executing ICRC-112

### Performance improvements:

* [`src/cashier_frontend/src/hooks/useLinkDataQuery.ts`](diffhunk://#diff-7546ad0c5fb788ef882a4bdcc5d8dafcd518ff68a9935f1bec7b7708760f9f64R13): Disabled refetch on window focus to potentially reduce unnecessary network requests.
* [`src/cashier_frontend/src/services/link.service.ts`](diffhunk://#diff-d1ac25396361f2774d98e27adffe5e7c607822dfab943855649504e8631e228eL53-R53): Increased the limit for fetching links from 10 to 30 to allow for a larger batch of links to be retrieved in a single request.