### PR TITLE
Add fee preview functionality for links

### DIFF
--- a/src/cashier_frontend/src/hooks/linkHooks.ts
+++ b/src/cashier_frontend/src/hooks/linkHooks.ts
@@ -4,7 +4,13 @@ import LinkService, {
     UpdateActionInputModel,
 } from "@/services/link.service";
 import { LinkDetailModel, State } from "@/services/types/link.service.types";
-import { QueryClient, useMutation, UseMutationResult, useQueryClient } from "@tanstack/react-query";
+import {
+    QueryClient,
+    useMutation,
+    UseMutationResult,
+    useQueryClient,
+    useQuery,
+} from "@tanstack/react-query";
 import { useIdentity } from "@nfid/identitykit/react";
 import { ACTION_STATE, ACTION_TYPE, LINK_TYPE } from "@/services/types/enum";
 import { MapLinkToLinkDetailModel } from "@/services/types/mapper/link.service.mapper";
@@ -246,4 +252,21 @@ export function useTransactionResultToast(
             }
         }
     }, [action]);
+}
+
+export function useFeePreview(linkId: string | undefined) {
+    const identity = useIdentity();
+
+    const query = useQuery({
+        queryKey: queryKeys.links.feePreview(linkId, identity).queryKey,
+        queryFn: async () => {
+            if (!linkId || !identity) return [];
+            const linkService = new LinkService(identity);
+            return linkService.getFeePreview(linkId);
+        },
+        enabled: !!linkId && !!identity,
+        refetchOnWindowFocus: false,
+    });
+
+    return query;
 }

--- a/src/cashier_frontend/src/lib/queryKeys.ts
+++ b/src/cashier_frontend/src/lib/queryKeys.ts
@@ -74,6 +74,17 @@ export const queryKeys = createQueryKeyStore({
                 }
             },
         }),
+        feePreview: (
+            linkId: string | undefined,
+            identity: Identity | PartialIdentity | undefined,
+        ) => ({
+            queryKey: ["links", "feePreview", linkId, identity],
+            queryFn: async () => {
+                if (!linkId || !identity) return [];
+                const linkService = new LinkService(identity);
+                return linkService.getFeePreview(linkId);
+            },
+        }),
     },
     tokens: {
         metadata: (tokenAddress: string | undefined) => ({

--- a/src/cashier_frontend/src/pages/edit/[id]/LinkPreview.tsx
+++ b/src/cashier_frontend/src/pages/edit/[id]/LinkPreview.tsx
@@ -1,5 +1,4 @@
 import { ConfirmationDrawer } from "@/components/confirmation-drawer/confirmation-drawer";
-import { useCashierFeeIntents } from "@/components/confirmation-drawer/confirmation-drawer.hooks";
 import { FeeInfoDrawer } from "@/components/fee-info-drawer/fee-info-drawer";
 import LinkCard from "@/components/link-card";
 import { LinkPreviewCashierFeeSection } from "@/components/link-preview/link-preview-cashier-fee-section";
@@ -10,7 +9,7 @@ import { LINK_TYPE } from "@/services/types/enum";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCreateLinkStore } from "@/stores/createLinkStore";
-import { useCreateAction } from "@/hooks/linkHooks";
+import { useCreateAction, useFeePreview } from "@/hooks/linkHooks";
 import { isCashierError } from "@/services/errorProcess.service";
 import { ActionModel } from "@/services/types/action.service.types";
 
@@ -28,12 +27,12 @@ export default function LinkPreview({
     const { t } = useTranslation();
 
     const { link, action, setAction } = useCreateLinkStore();
+    const { data: feeIntents = [] } = useFeePreview(link?.id);
 
     const [showInfo, setShowInfo] = useState(false);
     const [showConfirmation, setShowConfirmation] = useState(false);
     const [isDisabled, setIsDisabled] = useState(false);
 
-    const cashierFeeIntents = useCashierFeeIntents(action?.intents);
     const { mutateAsync: createAction } = useCreateAction();
 
     const handleCreateAction = async () => {
@@ -99,7 +98,7 @@ export default function LinkPreview({
             {renderLinkCard()}
 
             <LinkPreviewCashierFeeSection
-                intents={cashierFeeIntents}
+                intents={feeIntents}
                 onInfoClick={() => setShowInfo(true)}
             />
 


### PR DESCRIPTION
- Implemented `useFeePreview` hook to fetch fee preview for links
- Updated `LinkService` with `getFeePreview` method
- Added query key for fee preview in `queryKeys`
- Replaced `useCashierFeeIntents` with new `useFeePreview` in LinkPreview component