### PR TITLE
Add service to return mock data for preview fee

### DIFF
--- a/src/cashier_frontend/src/hooks/linkHooks.ts
+++ b/src/cashier_frontend/src/hooks/linkHooks.ts
@@ -4,7 +4,13 @@ import LinkService, {
     UpdateActionInputModel,
 } from "@/services/link.service";
 import { LinkDetailModel, State } from "@/services/types/link.service.types";
-import { QueryClient, useMutation, UseMutationResult, useQueryClient } from "@tanstack/react-query";
+import {
+    QueryClient,
+    useMutation,
+    UseMutationResult,
+    useQuery,
+    useQueryClient,
+} from "@tanstack/react-query";
 import { useIdentity } from "@nfid/identitykit/react";
 import { ACTION_STATE, ACTION_TYPE, LINK_TYPE } from "@/services/types/enum";
 import { MapLinkToLinkDetailModel } from "@/services/types/mapper/link.service.mapper";
@@ -246,4 +252,21 @@ export function useTransactionResultToast(
             }
         }
     }, [action]);
+}
+
+export function useFeePreview(linkId: string | undefined) {
+    const identity = useIdentity();
+
+    const query = useQuery({
+        queryKey: queryKeys.links.feePreview(linkId, identity).queryKey,
+        queryFn: async () => {
+            if (!linkId || !identity) return [];
+            const linkService = new LinkService(identity);
+            return linkService.getFeePreview(linkId);
+        },
+        enabled: !!linkId && !!identity,
+        refetchOnWindowFocus: false,
+    });
+
+    return query;
 }

--- a/src/cashier_frontend/src/lib/queryKeys.ts
+++ b/src/cashier_frontend/src/lib/queryKeys.ts
@@ -74,6 +74,17 @@ export const queryKeys = createQueryKeyStore({
                 }
             },
         }),
+        feePreview: (
+            linkId: string | undefined,
+            identity: Identity | PartialIdentity | undefined,
+        ) => ({
+            queryKey: ["links", "feePreview", linkId, identity],
+            queryFn: async () => {
+                if (!linkId || !identity) return [];
+                const linkService = new LinkService(identity);
+                return linkService.getFeePreview(linkId);
+            },
+        }),
     },
     tokens: {
         metadata: (tokenAddress: string | undefined) => ({

--- a/src/cashier_frontend/src/pages/edit/[id]/LinkPreview.tsx
+++ b/src/cashier_frontend/src/pages/edit/[id]/LinkPreview.tsx
@@ -9,7 +9,7 @@ import { LINK_TYPE } from "@/services/types/enum";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCreateLinkStore } from "@/stores/createLinkStore";
-import { useCreateAction } from "@/hooks/linkHooks";
+import { useCreateAction, useFeePreview } from "@/hooks/linkHooks";
 import { isCashierError } from "@/services/errorProcess.service";
 import { ActionModel } from "@/services/types/action.service.types";
 import { FixedBottomButton } from "@/components/fix-bottom-button";
@@ -36,7 +36,7 @@ export default function LinkPreview({
     const [isDisabled, setIsDisabled] = useState(false);
     const { mutateAsync: createAction } = useCreateAction();
 
-    const mockCashierFeeData: FeeModel[] = MOCK_CASHIER_FEES;
+    const { data: feeData } = useFeePreview(link?.id);
 
     const handleCreateAction = async () => {
         const updatedAction = await createAction({
@@ -104,7 +104,7 @@ export default function LinkPreview({
             {renderLinkCard()}
 
             <LinkPreviewCashierFeeSection
-                intents={mockCashierFeeData}
+                intents={feeData ?? []}
                 onInfoClick={() => setShowInfo(true)}
             />
 

--- a/src/cashier_frontend/src/services/link.service.ts
+++ b/src/cashier_frontend/src/services/link.service.ts
@@ -18,6 +18,8 @@ import {
 } from "./types/mapper/link.service.mapper";
 import { ActionModel } from "./types/action.service.types";
 import { mapActionModel } from "./types/mapper/action.service.mapper";
+import { FeeModel } from "./types/intent.service.types";
+import { MOCK_CASHIER_FEES } from "@/constants/mock-data";
 
 interface ResponseLinksModel {
     data: LinkModel[];
@@ -120,6 +122,11 @@ class LinkService {
         const response = parseResultResponse(await this.actor.update_action(input));
         const action = mapActionModel(response);
         return action;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async getFeePreview(linkId: string): Promise<FeeModel[]> {
+        return MOCK_CASHIER_FEES;
     }
 }
 


### PR DESCRIPTION
Following change(s):
- Add function to link service to get preview fee
- Add hooks to get link preview fees
- Change type of fees in Preview page