### PR TITLE
Fix frontend build local

### DIFF
--- a/src/cashier_frontend/package.json
+++ b/src/cashier_frontend/package.json
@@ -8,7 +8,7 @@
         "setup": "npm i && dfx canister create cashier_backend && dfx generate cashier_backend",
         "start": "vite --port 3000 --host --mode dev",
         "build": "tsc && vite build",
-        "build:local": "tsc && vite build --mode local",
+        "build:local": "tsc && vite build",
         "build:dev": "tsc && vite build --mode dev",
         "build:staging": "tsc && vite build --mode staging",
         "build:prod": "tsc && vite build --mode production",

--- a/src/cashier_frontend/vite.config.js
+++ b/src/cashier_frontend/vite.config.js
@@ -12,11 +12,11 @@ import crypto from "crypto";
 
 export default defineConfig(({ command, mode }) => {
     // Determine which .env file to use based on mode
-    // Supports: .env.local, .env.staging, .env.production
-    const envFile = `.env.${mode}`;
+    // Supports: .env.dev, .env.staging, .env.production
+    const envFile = `../../.env.${mode}`;
     const envPath = resolve(__dirname, envFile);
 
-    // Load the environment variables from the determined .env file
+    // Load the environment variables from the root .env file
     dotenv.config({ path: envPath });
 
     // Generate build information
@@ -31,7 +31,7 @@ export default defineConfig(({ command, mode }) => {
         .digest("hex")
         .substring(0, 8);
 
-    console.log(`Building for ${mode} environment using ${envFile}`);
+    console.log(`Building for ${mode} environment using root ${envFile} file`);
     console.log(`Build version: ${version}, Build hash: ${buildHash}`);
 
     return {


### PR DESCRIPTION
This pull request includes updates to the build configuration and environment setup for the `cashier_frontend` project. The changes simplify the build process and adjust the handling of environment files to align with a root-based structure.

### Build configuration updates:
* [`src/cashier_frontend/package.json`](diffhunk://#diff-249950b72705ebed01c24ae7be98896923118fc993e9c935f5d3453e38b78b05L11-R11): Removed the `--mode local` flag from the `build:local` script to standardize the build process. (`[src/cashier_frontend/package.jsonL11-R11](diffhunk://#diff-249950b72705ebed01c24ae7be98896923118fc993e9c935f5d3453e38b78b05L11-R11)`)

### Environment file handling:
* [`src/cashier_frontend/vite.config.js`](diffhunk://#diff-af2b9979698bbb48dee88ff468a7b1454c274159b5918fd268353b905daefca6L15-R19): Updated the path to environment files to use the root directory (`../../`) instead of the project directory, ensuring consistency across environments. (`[src/cashier_frontend/vite.config.jsL15-R19](diffhunk://#diff-af2b9979698bbb48dee88ff468a7b1454c274159b5918fd268353b905daefca6L15-R19)`)
* [`src/cashier_frontend/vite.config.js`](diffhunk://#diff-af2b9979698bbb48dee88ff468a7b1454c274159b5918fd268353b905daefca6L34-R34): Updated the console log message to reflect the use of the root `.env` file for builds. (`[src/cashier_frontend/vite.config.jsL34-R34](diffhunk://#diff-af2b9979698bbb48dee88ff468a7b1454c274159b5918fd268353b905daefca6L34-R34)`)