### PR TITLE
Bugfix/toggle default tokens

### DIFF
--- a/src/cashier_frontend/src/generated/token_storage/token_storage.did.d.ts
+++ b/src/cashier_frontend/src/generated/token_storage/token_storage.did.d.ts
@@ -65,6 +65,7 @@ export interface TokenDto {
   'balance' : [] | [bigint],
   'chain' : Chain,
   'name' : string,
+  'is_default' : boolean,
   'enabled' : boolean,
   'details' : ChainTokenDetails,
   'string_id' : string,

--- a/src/cashier_frontend/src/generated/token_storage/token_storage.did.js
+++ b/src/cashier_frontend/src/generated/token_storage/token_storage.did.js
@@ -44,6 +44,7 @@ export const idlFactory = ({ IDL }) => {
     'balance' : IDL.Opt(IDL.Nat),
     'chain' : Chain,
     'name' : IDL.Text,
+    'is_default' : IDL.Bool,
     'enabled' : IDL.Bool,
     'details' : ChainTokenDetails,
     'string_id' : IDL.Text,

--- a/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.d.ts
+++ b/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.d.ts
@@ -65,6 +65,7 @@ export interface TokenDto {
   'balance' : [] | [bigint],
   'chain' : Chain,
   'name' : string,
+  'is_default' : boolean,
   'enabled' : boolean,
   'details' : ChainTokenDetails,
   'string_id' : string,

--- a/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.js
+++ b/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.js
@@ -44,6 +44,7 @@ export const idlFactory = ({ IDL }) => {
     'balance' : IDL.Opt(IDL.Nat),
     'chain' : Chain,
     'name' : IDL.Text,
+    'is_default' : IDL.Bool,
     'enabled' : IDL.Bool,
     'details' : ChainTokenDetails,
     'string_id' : IDL.Text,

--- a/src/cashier_frontend_new/src/modules/token/services/tokenStorage.ts
+++ b/src/cashier_frontend_new/src/modules/token/services/tokenStorage.ts
@@ -33,7 +33,6 @@ class TokenStorageService {
       throw new Error("User is not authenticated");
     }
     const res: tokenStorage.Result_5 = await actor.list_tokens();
-    console.log("listTokens response:", res);
     return parseListTokens(res);
   }
 

--- a/src/cashier_frontend_new/src/modules/token/services/tokenStorage.ts
+++ b/src/cashier_frontend_new/src/modules/token/services/tokenStorage.ts
@@ -33,6 +33,7 @@ class TokenStorageService {
       throw new Error("User is not authenticated");
     }
     const res: tokenStorage.Result_5 = await actor.list_tokens();
+    console.log("listTokens response:", res);
     return parseListTokens(res);
   }
 

--- a/src/cashier_frontend_new/src/modules/token/state/walletStore.svelte.ts
+++ b/src/cashier_frontend_new/src/modules/token/state/walletStore.svelte.ts
@@ -11,6 +11,7 @@ import type { TokenWithPriceAndBalance } from "$modules/token/types";
 import { Principal } from "@dfinity/principal";
 import { Err, Ok, type Result } from "ts-results-es";
 import { ICP_LEDGER_CANISTER_ID } from "../constants";
+import { sortWalletTokens } from "../utils/sorter";
 
 export class WalletStore {
   #walletTokensQuery;
@@ -41,10 +42,7 @@ export class WalletStore {
           priceUSD: prices[token.address] || 0,
         }));
 
-        // sort by address
-        enrichedTokens.sort((a, b) => a.address.localeCompare(b.address));
-
-        return enrichedTokens;
+        return sortWalletTokens(enrichedTokens);
       },
       refetchInterval: 15_000, // Refresh every 15 seconds to keep balances up-to-date
       persistedKey: ["walletTokensQuery"],

--- a/src/cashier_frontend_new/src/modules/token/types.ts
+++ b/src/cashier_frontend_new/src/modules/token/types.ts
@@ -8,6 +8,7 @@ export type TokenMetadata = {
   decimals: number;
   enabled: boolean;
   fee: bigint;
+  is_default: boolean;
 };
 
 /**

--- a/src/cashier_frontend_new/src/modules/token/utils/parser.spec.ts
+++ b/src/cashier_frontend_new/src/modules/token/utils/parser.spec.ts
@@ -55,6 +55,7 @@ describe("parseListTokens", () => {
                 index_id: [],
               },
             },
+            is_default: true,
           },
         ],
       },
@@ -72,6 +73,7 @@ describe("parseListTokens", () => {
         decimals: 8,
         enabled: true,
         fee: 10000n,
+        is_default: true,
       },
     ]);
   });

--- a/src/cashier_frontend_new/src/modules/token/utils/parser.ts
+++ b/src/cashier_frontend_new/src/modules/token/utils/parser.ts
@@ -26,6 +26,7 @@ export function parseListTokens(
             decimals: token.decimals,
             enabled: token.enabled,
             fee: token.details.IC.fee,
+            is_default: token.is_default,
           };
         },
       });

--- a/src/cashier_frontend_new/src/modules/token/utils/sorter.spec.ts
+++ b/src/cashier_frontend_new/src/modules/token/utils/sorter.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { ICP_LEDGER_CANISTER_ID } from "../constants";
+import type { TokenWithPriceAndBalance } from "../types";
+import { sortWalletTokens } from "./sorter";
+
+describe("sortWalletTokens", () => {
+  it("should sort tokens correctly", () => {
+    const tokens: TokenWithPriceAndBalance[] = [
+      {
+        address: "oj6if-riaaa-aaaaq-aaeha-cai",
+        name: "Alice coin",
+        symbol: "ALICE",
+        priceUSD: 0.00001,
+        balance: 0n,
+        decimals: 18,
+        enabled: true,
+        fee: 10000n,
+        is_default: false,
+      },
+      {
+        address: "mxzaz-hqaaa-aaaar-qaada-cai",
+        name: "Chainkey Bitcoin",
+        symbol: "ckBTC",
+        priceUSD: 100000.01,
+        balance: 0n,
+        decimals: 8,
+        enabled: true,
+        fee: 10n,
+        is_default: true,
+      },
+      {
+        address: ICP_LEDGER_CANISTER_ID,
+        name: "Internet Computer",
+        symbol: "ICP",
+        priceUSD: 5.01,
+        balance: 0n,
+        decimals: 8,
+        enabled: true,
+        fee: 10000n,
+        is_default: true,
+      },
+      {
+        address: "xevnm-gaaaa-aaaar-qafnq-cai",
+        name: "Chainkey USDC",
+        symbol: "ckUSDC",
+        priceUSD: 1.0,
+        balance: 0n,
+        decimals: 8,
+        enabled: true,
+        fee: 10000n,
+        is_default: true,
+      },
+      {
+        address: "ss2fx-dyaaa-aaaar-qacoq-cai",
+        name: "Chainkey Ethereum",
+        symbol: "ckETH",
+        priceUSD: 4500.0,
+        balance: 0n,
+        decimals: 18,
+        enabled: true,
+        fee: 2_000_000_000n,
+        is_default: false,
+      },
+    ];
+
+    const sortedTokens = sortWalletTokens(tokens);
+    const sortedAddresses = sortedTokens.map((t) => t.address);
+
+    expect(sortedAddresses).toEqual([
+      ICP_LEDGER_CANISTER_ID, // ICP first
+      "mxzaz-hqaaa-aaaar-qaada-cai", // then default tokens sorted by address
+      "xevnm-gaaaa-aaaar-qafnq-cai",
+      "oj6if-riaaa-aaaaq-aaeha-cai", // then non-default tokens sorted by address
+      "ss2fx-dyaaa-aaaar-qacoq-cai",
+    ]);
+  });
+});

--- a/src/cashier_frontend_new/src/modules/token/utils/sorter.ts
+++ b/src/cashier_frontend_new/src/modules/token/utils/sorter.ts
@@ -1,0 +1,28 @@
+import { ICP_LEDGER_CANISTER_ID } from "../constants";
+import type { TokenWithPriceAndBalance } from "../types";
+
+/**
+ * Sorts an array of wallet tokens with the following criteria:
+ * 1. ICP token first
+ * 2. Then by default tokens (is_default = true)
+ * 3. Within same group (both default or both non-default), sort by address
+ * @param enrichedTokens Array of tokens with price and balance information
+ * @return Sorted array of tokens
+ */
+export function sortWalletTokens(
+  enrichedTokens: TokenWithPriceAndBalance[],
+): TokenWithPriceAndBalance[] {
+  // Sort tokens: ICP first, then default tokens (by address), then non-default tokens (by address)
+  return [...enrichedTokens].sort((a, b) => {
+    // 1. ICP token first
+    if (a.address === ICP_LEDGER_CANISTER_ID) return -1;
+    if (b.address === ICP_LEDGER_CANISTER_ID) return 1;
+
+    // 2. Then by default tokens
+    if (a.is_default && !b.is_default) return -1;
+    if (!a.is_default && b.is_default) return 1;
+
+    // 3. Within same group (both default or both non-default), sort by address
+    return a.address.localeCompare(b.address);
+  });
+}

--- a/src/cashier_frontend_new/src/routes/wallet/manage/+page.svelte
+++ b/src/cashier_frontend_new/src/routes/wallet/manage/+page.svelte
@@ -38,6 +38,7 @@
               <input
                 type="checkbox"
                 checked={token.enabled}
+                disabled={token.is_default}
                 onchange={() => handleToggle(token)}
               />
               Enabled

--- a/src/integration_tests/tests/token_storage/token.rs
+++ b/src/integration_tests/tests/token_storage/token.rs
@@ -11,8 +11,8 @@ async fn should_register_tokens_at_startup() {
 
         // Assert
         assert!(!tokens.tokens.is_empty());
-
         assert!(tokens.tokens.iter().any(|token| { token.symbol == "ICP" }));
+        assert!(tokens.tokens.iter().all(|token| token.is_default));
 
         Ok(())
     })

--- a/src/token_storage_types/src/token.rs
+++ b/src/token_storage_types/src/token.rs
@@ -94,6 +94,7 @@ impl From<RegistryToken> for TokenDto {
             enabled: token.enabled_by_default,
             balance: None,
             details: token.details, // Directly use the enum
+            is_default: token.enabled_by_default,
         }
     }
 }
@@ -112,6 +113,7 @@ pub struct TokenDto {
     pub enabled: bool,
     pub balance: Option<u128>,
     pub details: ChainTokenDetails, // Use the enum for chain-specific details
+    pub is_default: bool,
 }
 
 #[derive(CandidType, Deserialize, Serialize, Clone, Debug)]


### PR DESCRIPTION
This PR fixes the bugs of toggling default tokens in wallets.
- Disable the toggle button of default tokens in tokens list.
- Sort the tokens list by following rules: ICP first, then default tokens by address, then user added tokens by address.