### PR TITLE
Fixbug: deploy to orbit haven't trigged after merged

### DIFF
--- a/.github/workflows/fast-forward-merge.yml
+++ b/.github/workflows/fast-forward-merge.yml
@@ -16,6 +16,7 @@ jobs:
       pull-requests: write
       issues: write
       checks: read
+      actions: write
 
     steps:
       # Step 2: Check all CI checks passed
@@ -237,3 +238,67 @@ jobs:
         with:
           merge: true
           comment: always
+
+      # Step 7: Trigger deploy workflows based on changed files
+      - name: Trigger deploy workflows
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            // Only trigger deploys for main/staging branches
+            const targetBranch = pr.base.ref;
+            if (!['main', 'staging'].includes(targetBranch)) {
+              console.log(`Skipping deploy for branch: ${targetBranch}`);
+              return;
+            }
+
+            // Get changed files
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const changedPaths = files.map(f => f.filename);
+            console.log('Changed files:', changedPaths);
+
+            // Define path patterns (must match deploy workflow paths)
+            const backendPaths = ['src/cashier_backend/', 'src/token_storage/', 'src/transaction_manager/'];
+            const frontendPaths = ['src/cashier_frontend_new/'];
+
+            const hasBackendChanges = changedPaths.some(p =>
+              backendPaths.some(bp => p.startsWith(bp))
+            );
+            const hasFrontendChanges = changedPaths.some(p =>
+              frontendPaths.some(fp => p.startsWith(fp))
+            );
+
+            // Trigger backend deploy if needed
+            if (hasBackendChanges) {
+              console.log('Triggering backend deploy...');
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'orbit-backend-deploy.yml',
+                ref: targetBranch
+              });
+            }
+
+            // Trigger frontend deploy if needed
+            if (hasFrontendChanges) {
+              console.log('Triggering frontend deploy...');
+              await github.rest.actions.createWorkflowDispatch({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'orbit-frontend-deploy.yml',
+                ref: targetBranch
+              });
+            }
+
+            console.log(`Backend: ${hasBackendChanges}, Frontend: ${hasFrontendChanges}`);

--- a/.github/workflows/orbit-backend-deploy.yml
+++ b/.github/workflows/orbit-backend-deploy.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'src/cashier_backend/**'
       - 'src/token_storage/**'
+      - 'src/transaction_manager/**'
   workflow_dispatch:
     inputs:
       mode:


### PR DESCRIPTION
  ### Root Cause                                                                                     
                                                                                                     
  **GitHub doesn't emit a `push` event for fast-forward merges done via the API.**                   
                                                                                                     
  ### The Flow Before                                                                                
                                                                                                     
  PR to main → /fast-forward comment                                                                 
                     ↓                                                                               
           sequoia-pgp/fast-forward action                                                           
                     ↓                                                                               
           Updates branch ref via GitHub API                                                         
                     ↓                                                                               
           NO "push" event emitted ❌                                                                
                     ↓                                                                               
           Deploy workflows never triggered                                                          
                                                                                                     
  ### Why?                                                                                           
                                                                                                     
  | Merge Type | How It Works | Push Event? |                                                        
  |------------|--------------|-------------|                                                        
  | Regular merge | Creates merge commit | ✅ Yes |                                                  
  | Squash merge | Creates new commit | ✅ Yes |                                                     
  | Fast-forward (API) | Moves ref pointer only | ❌ No |                                            
                                                                                                     
  The `sequoia-pgp/fast-forward` action uses GitHub's Git References API to update the branch        
  pointer. This is a **ref update**, not a **push operation**, so GitHub doesn't fire the `push`     
  webhook event that the deploy workflows were listening for.                                        
                                                                                                     
  ### The Fix                                                                                        
                                                                                                     
  Added Step 7 to explicitly call `workflow_dispatch` API after successful fast-forward, manually    
  triggering the deploy workflows based on changed file paths.       