### PR TITLE
[Ticket #869bxjvjw] Improve integration test speed - part 2

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -54,8 +54,8 @@ jobs:
         run: |
           just check_code
 
-  backend-test:
-    name: "Backend Build and Test"
+  backend-build:
+    name: "Backend Build"
     if: github.event.pull_request.draft == false || github.event_name == 'push'
     permissions:
       contents: read
@@ -99,9 +99,58 @@ jobs:
         run: |
           just build
 
-      - name: Test
+      - name: Unit Test
         run: |
-          just test
+          just test_unit
+
+      - name: Upload wasm artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wasm-artifacts
+          path: target/artifacts/
+          retention-days: 1
+
+  integration-test:
+    name: "Integration Test (shard ${{ matrix.partition }}/${{ matrix.total }})"
+    needs: backend-build
+    if: github.event.pull_request.draft == false || github.event_name == 'push'
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [1, 2, 3]
+        total: [3]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Just command runner
+        uses: extractions/setup-just@v1
+
+      - name: Install cargo-nextest
+        run: |
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /usr/local/bin
+
+      - name: Configure Rust Cache
+        uses: swatinem/rust-cache@v2
+        if: ${{ (github.event.pull_request.base.ref != 'main') && (github.ref_name != 'main') }}
+        with:
+          shared-key: ${{ github.repository }}
+          save-if: false
+
+      - name: Download wasm artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: wasm-artifacts
+          path: target/artifacts
+
+      - name: Run integration tests (shard ${{ matrix.partition }}/${{ matrix.total }})
+        run: |
+          just test_integration ${{ matrix.partition }} ${{ matrix.total }}
 
   backend-test-i686:
     name: "Backend Test (i686)"

--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -130,8 +130,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3]
-        total: [3]
+        partition: [1, 2, 3, 4]
+        total: [4]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -151,6 +151,18 @@ jobs:
             --workspace-remap ${{ github.workspace }} \
             --partition count:${{ matrix.partition }}/${{ matrix.total }}
 
+  cleanup-artifacts:
+    name: "Cleanup Artifacts"
+    needs: integration-test
+    if: always()
+    permissions:
+      actions: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: geekyeggo/delete-artifact@v5
+        with:
+          name: test-artifacts
+
   backend-test-i686:
     name: "Backend Test (i686)"
     if: github.event.pull_request.draft == false || github.event_name == 'push'

--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -133,6 +133,8 @@ jobs:
         partition: [1, 2, 3]
         total: [3]
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install cargo-nextest
         run: |
           curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /usr/local/bin
@@ -146,6 +148,7 @@ jobs:
       - name: Run integration tests (shard ${{ matrix.partition }}/${{ matrix.total }})
         run: |
           cargo nextest run --archive-file target/nextest-archive.tar.zst \
+            --workspace-remap ${{ github.workspace }} \
             --partition count:${{ matrix.partition }}/${{ matrix.total }}
 
   backend-test-i686:

--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -130,8 +130,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2, 3, 4]
-        total: [4]
+        partition: [1, 2, 3]
+        total: [3]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -103,11 +103,21 @@ jobs:
         run: |
           just test_unit
 
-      - name: Upload wasm artifacts
+      - name: Install cargo-nextest
+        run: |
+          curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /usr/local/bin
+
+      - name: Create nextest archive
+        run: |
+          cargo nextest archive -p integration_tests --archive-file target/nextest-archive.tar.zst
+
+      - name: Upload test artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wasm-artifacts
-          path: target/artifacts/
+          name: test-artifacts
+          path: |
+            target/artifacts/
+            target/nextest-archive.tar.zst
           retention-days: 1
 
   integration-test:
@@ -123,34 +133,20 @@ jobs:
         partition: [1, 2, 3]
         total: [3]
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install Just command runner
-        uses: extractions/setup-just@v1
-
       - name: Install cargo-nextest
         run: |
           curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /usr/local/bin
 
-      - name: Configure Rust Cache
-        uses: swatinem/rust-cache@v2
-        if: ${{ (github.event.pull_request.base.ref != 'main') && (github.ref_name != 'main') }}
-        with:
-          shared-key: ${{ github.repository }}
-          save-if: false
-
-      - name: Download wasm artifacts
+      - name: Download test artifacts
         uses: actions/download-artifact@v4
         with:
-          name: wasm-artifacts
-          path: target/artifacts
+          name: test-artifacts
+          path: target
 
       - name: Run integration tests (shard ${{ matrix.partition }}/${{ matrix.total }})
         run: |
-          just test_integration ${{ matrix.partition }} ${{ matrix.total }}
+          cargo nextest run --archive-file target/nextest-archive.tar.zst \
+            --partition count:${{ matrix.partition }}/${{ matrix.total }}
 
   backend-test-i686:
     name: "Backend Test (i686)"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,7 @@ dependencies = [
  "icrc-ledger-types",
  "serde",
  "serde_bytes",
+ "serde_json",
  "token_storage_client",
  "token_storage_types",
  "tokio",

--- a/just/test.just
+++ b/just/test.just
@@ -17,6 +17,10 @@ test test_name="": download_artifacts build_canisters
 
 
 # Run integration tests only (supports nextest sharding)
+# If partition and total are provided, runs only that partition of tests.
+# Args:
+# partition: which partition to run (1-based index)
+# total: total number of partitions
 [group('test')]
 test_integration partition="" total="":
   #!/usr/bin/env bash

--- a/just/test.just
+++ b/just/test.just
@@ -16,7 +16,7 @@ test test_name="": download_artifacts build_canisters
   cargo test {{test_name}}
 
 
-# Run integration tests only (for CI sharding with nextest)
+# Run integration tests only (supports nextest sharding)
 [group('test')]
 test_integration partition="" total="":
   #!/usr/bin/env bash
@@ -31,6 +31,11 @@ test_integration partition="" total="":
   else
     cargo nextest run -p integration_tests
   fi
+
+# Build nextest archive for integration tests (used by CI)
+[group('test')]
+test_integration_archive:
+  cargo nextest archive -p integration_tests --archive-file target/nextest-archive.tar.zst
 
 
 # Run unit tests for the i686 target

--- a/just/test.just
+++ b/just/test.just
@@ -16,6 +16,23 @@ test test_name="": download_artifacts build_canisters
   cargo test {{test_name}}
 
 
+# Run integration tests only (for CI sharding with nextest)
+[group('test')]
+test_integration partition="" total="":
+  #!/usr/bin/env bash
+  set -e
+  # Clean stale lock/ready files to ensure fresh template deployment
+  rm -f ./target/pocket-ic-test-state/template.lock
+  rm -f ./target/pocket-ic-test-state/template.ready
+  rm -f ./target/pocket-ic-test-state/principals.json
+  rm -rf ./target/pocket-ic-test-state/template
+  if [ -n "{{partition}}" ] && [ -n "{{total}}" ]; then
+    cargo nextest run -p integration_tests --partition count:{{partition}}/{{total}}
+  else
+    cargo nextest run -p integration_tests
+  fi
+
+
 # Run unit tests for the i686 target
 [group('test')]
 test_unit_i686 test_name="":

--- a/src/integration_tests/Cargo.toml
+++ b/src/integration_tests/Cargo.toml
@@ -22,6 +22,7 @@ ic_mple_pocket_ic = { workspace = true }
 icrc-ledger-types = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
+serde_json = { workspace = true }
 token_storage_client = { workspace = true }
 token_storage_types = { workspace = true }
 tokio = { workspace = true }

--- a/src/integration_tests/tests/utils/mod.rs
+++ b/src/integration_tests/tests/utils/mod.rs
@@ -26,12 +26,12 @@ use std::{
     },
     time::Duration,
 };
-use tokio::sync::OnceCell;
 use token_storage_client::client::TokenStorageClient;
 use token_storage_types::{
     init::TokenStorageInitData,
     token::{ChainTokenDetails, RegistryToken},
 };
+use tokio::sync::OnceCell;
 
 pub mod icrc_112;
 pub mod link_id_to_account;
@@ -92,8 +92,8 @@ async fn init_shared_state() -> SharedTestState {
     };
 
     // Create empty template dir for state persistence under ./target
-    let template_dir = PathBuf::from(POCKET_IC_STATE_DIR)
-        .join(format!("template-{}", std::process::id()));
+    let template_dir =
+        PathBuf::from(POCKET_IC_STATE_DIR).join(format!("template-{}", std::process::id()));
     if template_dir.exists() {
         std::fs::remove_dir_all(&template_dir).unwrap();
     }
@@ -332,10 +332,9 @@ where
 
     // Copy template state to unique temp dir for this test
     let test_id = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let test_dir = PathBuf::from(POCKET_IC_STATE_DIR)
-        .join(format!("test-{}-{}", std::process::id(), test_id));
-    copy_dir_all(&shared.template_dir, &test_dir)
-        .expect("Failed to copy template state dir");
+    let test_dir =
+        PathBuf::from(POCKET_IC_STATE_DIR).join(format!("test-{}-{}", std::process::id(), test_id));
+    copy_dir_all(&shared.template_dir, &test_dir).expect("Failed to copy template state dir");
 
     // Mount state from copied dir (skips canister deployment)
     let client = Arc::new(

--- a/src/integration_tests/tests/utils/mod.rs
+++ b/src/integration_tests/tests/utils/mod.rs
@@ -15,11 +15,6 @@ use ic_mple_client::PocketIcClient;
 use ic_mple_log::service::LogServiceSettings;
 use ic_mple_pocket_ic::{get_pocket_ic_client, pocket_ic::nonblocking::PocketIc};
 use serde::{Deserialize, Serialize};
-use token_storage_client::client::TokenStorageClient;
-use token_storage_types::{
-    init::TokenStorageInitData,
-    token::{ChainTokenDetails, RegistryToken},
-};
 use std::{
     collections::HashMap,
     fs::File,
@@ -30,6 +25,11 @@ use std::{
         atomic::{AtomicU64, Ordering},
     },
     time::Duration,
+};
+use token_storage_client::client::TokenStorageClient;
+use token_storage_types::{
+    init::TokenStorageInitData,
+    token::{ChainTokenDetails, RegistryToken},
 };
 
 pub mod icrc_112;
@@ -344,8 +344,8 @@ where
 
     // Copy template state to unique temp dir for this test
     let test_id = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let test_dir = PathBuf::from(POCKET_IC_STATE_DIR)
-        .join(format!("test-{}-{}", std::process::id(), test_id));
+    let test_dir =
+        PathBuf::from(POCKET_IC_STATE_DIR).join(format!("test-{}-{}", std::process::id(), test_id));
     copy_dir_all(&template_dir, &test_dir).expect("Failed to copy template state dir");
 
     // Mount state from copied dir (skips canister deployment)

--- a/src/integration_tests/tests/utils/mod.rs
+++ b/src/integration_tests/tests/utils/mod.rs
@@ -31,7 +31,6 @@ use token_storage_types::{
     init::TokenStorageInitData,
     token::{ChainTokenDetails, RegistryToken},
 };
-use tokio::sync::OnceCell;
 
 pub mod icrc_112;
 pub mod link_id_to_account;

--- a/src/integration_tests/tests/utils/mod.rs
+++ b/src/integration_tests/tests/utils/mod.rs
@@ -19,10 +19,14 @@ use std::{
     collections::HashMap,
     fs::File,
     io::Read,
-    path::PathBuf,
-    sync::{Arc, OnceLock},
+    path::{Path, PathBuf},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Duration,
 };
+use tokio::sync::OnceCell;
 use token_storage_client::client::TokenStorageClient;
 use token_storage_types::{
     init::TokenStorageInitData,
@@ -35,15 +39,51 @@ pub mod principal;
 pub mod token_icp;
 pub mod token_icrc;
 
-/// Executes the provided asynchronous function within a `PocketIcTestContext` environment.
-///
-/// This function sets up a client and deploys a canister with the provided bytecode to the local
-/// IC instance. It then executes the given asynchronous function `f` with the initialized
-/// `PocketIcTestContext`, which contains the client and the canister's principal.
-pub async fn with_pocket_ic_context<F, E>(f: F) -> Result<(), E>
-where
-    F: AsyncFnOnce(&PocketIcTestContext) -> Result<(), E>,
-{
+/// Shared test state: template state_dir path + canister principals.
+/// Initialized once via OnceCell, reused across all tests.
+/// Cleans up template_dir on drop (process exit).
+struct SharedTestState {
+    template_dir: PathBuf,
+    principals: SharedPrincipals,
+}
+
+impl Drop for SharedTestState {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.template_dir);
+    }
+}
+
+/// Canister principals deployed in the shared template state
+#[derive(Clone)]
+struct SharedPrincipals {
+    token_storage: Principal,
+    cashier_backend: Principal,
+    gate_service: Principal,
+    icp_ledger: Principal,
+    icrc_tokens: HashMap<String, Principal>,
+    icrc7_ledger: Principal,
+    ckbtc_minter: Principal,
+    ckbtc_kyt: Principal,
+}
+
+/// Base path for PocketIC test state directories
+const POCKET_IC_STATE_DIR: &str = "../../target/pocket-ic-test-state";
+
+/// Global shared state - deployed once, mounted per test via state_dir copy
+static SHARED_STATE: OnceCell<SharedTestState> = OnceCell::const_new();
+
+/// Atomic counter for unique test dir names
+static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Get or initialize the shared test state
+async fn get_shared_state() -> &'static SharedTestState {
+    SHARED_STATE
+        .get_or_init(|| async { init_shared_state().await })
+        .await
+}
+
+/// Deploy all canisters once, persist state to template_dir on disk
+async fn init_shared_state() -> SharedTestState {
     let log = LogServiceSettings {
         enable_console: Some(true),
         in_memory_records: None,
@@ -51,7 +91,20 @@ where
         log_filter: Some("debug".to_string()),
     };
 
-    let client = Arc::new(get_pocket_ic_client().await.build_async().await);
+    // Create empty template dir for state persistence under ./target
+    let template_dir = PathBuf::from(POCKET_IC_STATE_DIR)
+        .join(format!("template-{}", std::process::id()));
+    if template_dir.exists() {
+        std::fs::remove_dir_all(&template_dir).unwrap();
+    }
+    std::fs::create_dir_all(&template_dir).unwrap();
+
+    // Build PocketIC with state_dir to persist canister state to disk
+    let client = get_pocket_ic_client()
+        .await
+        .with_state_dir(template_dir.clone())
+        .build_async()
+        .await;
 
     let ckbtc_kyt_principal = ckbtc::kyt::deploy_ckbtc_kyt_canister(
         &client,
@@ -152,12 +205,11 @@ where
         &(CashierBackendInitData {
             log_settings: Some(log.clone()),
             owner: TestUser::CashierBackendAdmin.get_principal(),
-            token_fee_ttl_ns: Some(168 * 60 * 60 * 1_000_000_000), // 168 hours
+            token_fee_ttl_ns: Some(168 * 60 * 60 * 1_000_000_000),
         }),
     )
     .await;
 
-    // Deploy gate_service and set GateCreator permissions for cashier_backend
     let gate_service_principal = deploy_canister(
         &client,
         None,
@@ -173,7 +225,6 @@ where
     )
     .await;
 
-    // Deploy ICP and ICRC ledger canisters
     let icp_ledger_principal = token_icp::deploy_icp_ledger_canister(&client).await;
 
     let mut icrc_token_map = HashMap::new();
@@ -223,7 +274,6 @@ where
     icrc_token_map.insert("ckUSDC".to_string(), ck_usdc_principal);
     icrc_token_map.insert("DOGE".to_string(), doge_principal);
 
-    // deploy ICRC7 NFT canister
     let icrc7_ledger_principal = icrc7::utils::deploy_icrc7_ledger_canister(
         &client,
         "TestCollection",
@@ -233,22 +283,88 @@ where
     )
     .await;
 
+    let principals = SharedPrincipals {
+        token_storage: token_storage_principal,
+        cashier_backend: cashier_backend_principal,
+        gate_service: gate_service_principal,
+        icp_ledger: icp_ledger_principal,
+        icrc_tokens: icrc_token_map,
+        icrc7_ledger: icrc7_ledger_principal,
+        ckbtc_minter: ckbtc_minter_principal,
+        ckbtc_kyt: ckbtc_kyt_principal,
+    };
+
+    // Drop PocketIC instance - state is persisted in template_dir
+    client.drop().await;
+
+    SharedTestState {
+        template_dir,
+        principals,
+    }
+}
+
+/// Recursively copy directory contents for test isolation
+fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let dst_path = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir_all(&entry.path(), &dst_path)?;
+        } else {
+            std::fs::copy(entry.path(), &dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+/// Executes the provided asynchronous function within a `PocketIcTestContext` environment.
+///
+/// Uses shared state_dir for fast test execution. First call deploys all canisters
+/// and persists state to disk (~30s). Subsequent calls copy the template state_dir
+/// to a unique temp dir and mount it (~1s). Each test gets full isolation via
+pub async fn with_pocket_ic_context<F, E>(f: F) -> Result<(), E>
+where
+    F: AsyncFnOnce(&PocketIcTestContext) -> Result<(), E>,
+{
+    let shared = get_shared_state().await;
+
+    // Copy template state to unique temp dir for this test
+    let test_id = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let test_dir = PathBuf::from(POCKET_IC_STATE_DIR)
+        .join(format!("test-{}-{}", std::process::id(), test_id));
+    copy_dir_all(&shared.template_dir, &test_dir)
+        .expect("Failed to copy template state dir");
+
+    // Mount state from copied dir (skips canister deployment)
+    let client = Arc::new(
+        get_pocket_ic_client()
+            .await
+            .with_state_dir(test_dir.clone())
+            .build_async()
+            .await,
+    );
+
     let result = f(&PocketIcTestContext {
         client: client.clone(),
-        token_storage_principal,
-        cashier_backend_principal,
-        gate_service_principal,
-        icp_ledger_principal,
-        icrc_token_map,
-        icrc7_ledger_principal,
-        ckbtc_minter_principal,
-        ckbtc_kyt_principal,
+        token_storage_principal: shared.principals.token_storage,
+        cashier_backend_principal: shared.principals.cashier_backend,
+        gate_service_principal: shared.principals.gate_service,
+        icp_ledger_principal: shared.principals.icp_ledger,
+        icrc_token_map: shared.principals.icrc_tokens.clone(),
+        icrc7_ledger_principal: shared.principals.icrc7_ledger,
+        ckbtc_minter_principal: shared.principals.ckbtc_minter,
+        ckbtc_kyt_principal: shared.principals.ckbtc_kyt,
     })
     .await;
 
     if let Ok(client) = Arc::try_unwrap(client) {
-        client.drop().await
+        client.drop().await;
     }
+
+    // Cleanup test state dir
+    let _ = std::fs::remove_dir_all(&test_dir);
 
     result
 }


### PR DESCRIPTION
Ticket https://app.clickup.com/t/869bxjvjw
Updates:
- Update test command to `cargo nextest run` for integration test
- Apply partition for github action, now all the test will run in 3 shards in parallel with `cargo nextest run --partition n/3` command
- Auto delete artifact to avoid reach limit of github
