### PR TITLE
[Ticket #869c34dbw] centralize canister call to use signer agent

### DIFF
--- a/src/cashier_frontend_new/package-lock.json
+++ b/src/cashier_frontend_new/package-lock.json
@@ -17,6 +17,7 @@
         "@dfinity/principal": "^2.4.1",
         "@dfinity/utils": "^2.14.0",
         "@slide-computer/signer": "^3.20.0",
+        "@slide-computer/signer-agent": "^3.20.0",
         "@windoge98/plug-n-play": "^0.1.0-beta.25",
         "axios": "^1.13.1",
         "devalue": "^5.3.2",

--- a/src/cashier_frontend_new/package.json
+++ b/src/cashier_frontend_new/package.json
@@ -64,7 +64,6 @@
   },
   "dependencies": {
     "@dfinity/agent": "2.4.1",
-    "@slide-computer/signer": "^3.20.0",
     "@dfinity/auth-client": "2.4.1",
     "@dfinity/candid": "2.4.1",
     "@dfinity/identity": "2.4.1",
@@ -72,6 +71,8 @@
     "@dfinity/ledger-icrc": "^2.7.0",
     "@dfinity/principal": "^2.4.1",
     "@dfinity/utils": "^2.14.0",
+    "@slide-computer/signer": "^3.20.0",
+    "@slide-computer/signer-agent": "^3.20.0",
     "@windoge98/plug-n-play": "^0.1.0-beta.25",
     "axios": "^1.13.1",
     "devalue": "^5.3.2",

--- a/src/cashier_frontend_new/src/modules/auth/signer/ii/IIChannel.ts
+++ b/src/cashier_frontend_new/src/modules/auth/signer/ii/IIChannel.ts
@@ -252,11 +252,13 @@ export class IIChannel implements Channel {
         const canisterId = Principal.fromText(
           callCanisterRequest.params!.canisterId,
         );
-        if (
-          callCanisterRequest.params?.sender !==
-          this.#agent.getPrincipal().toString()
-        ) {
-          throw new IITransportError("Sender does not match Agent identity");
+        const agentPrincipal = await this.#agent.getPrincipal();
+        if (callCanisterRequest.params?.sender !== agentPrincipal.toString()) {
+          throw new IITransportError(
+            `Sender does not match Agent identity. ` +
+              `sender=${callCanisterRequest.params?.sender}, ` +
+              `agent=${agentPrincipal.toString()}`,
+          );
         }
         const agent = await HttpAgent.from(this.#agent);
         let contentMap: ArrayBuffer;
@@ -359,7 +361,7 @@ export class IIChannel implements Channel {
                 }
                 try {
                   const canisterId = Principal.fromText(request.canisterId);
-                  const agent = this.#agent;
+                  const agent = await HttpAgent.from(this.#agent);
                   let contentMap: ArrayBuffer =
                     undefined as unknown as ArrayBuffer;
                   agent.addTransform("update", async (agentRequest) => {

--- a/src/cashier_frontend_new/src/modules/auth/signer/ii/IISignerAdapter.ts
+++ b/src/cashier_frontend_new/src/modules/auth/signer/ii/IISignerAdapter.ts
@@ -6,6 +6,7 @@ import { IITransport } from "./IITransport";
 import { FEATURE_FLAGS, HOST_ICP } from "$modules/shared/constants";
 import { getScreenDimensions } from "$modules/shared/utils/getScreenDimensions";
 import { Signer } from "@slide-computer/signer";
+import { SignerAgent } from "@slide-computer/signer-agent";
 
 /**
  * Account interface representing the connected user's account details.
@@ -23,7 +24,7 @@ interface Account {
 export class IISignerAdapter extends BaseSignerAdapter<IIAdapterConfig> {
   // II specific properties
   private authClient: AuthClient | null = null;
-  private identity: Identity | null = null;
+  #signerAgent: SignerAgent | null = null;
 
   constructor(
     args: { adapter: unknown; config: IIAdapterConfig } | IIAdapterConfig,
@@ -60,6 +61,10 @@ export class IISignerAdapter extends BaseSignerAdapter<IIAdapterConfig> {
 
   getAuthClient(): AuthClient | null {
     return this.authClient;
+  }
+
+  getSignerAgent(): SignerAgent | null {
+    return this.#signerAgent;
   }
 
   protected ensureTransportInitialized(): Promise<void> {
@@ -105,7 +110,7 @@ export class IISignerAdapter extends BaseSignerAdapter<IIAdapterConfig> {
 
   // Use the resolved config for agent initialization
   private async initAgentAndSigner(identity: Identity): Promise<void> {
-    const agent = HttpAgent.createSync({
+    const agent = await HttpAgent.create({
       identity,
       host: HOST_ICP,
       shouldFetchRootKey: FEATURE_FLAGS.LOCAL_IDENTITY_PROVIDER_ENABLED,
@@ -117,6 +122,11 @@ export class IISignerAdapter extends BaseSignerAdapter<IIAdapterConfig> {
     this.agent = agent;
     this.signer = new Signer<IITransport>({
       transport: transport,
+    });
+    this.#signerAgent = SignerAgent.createSync({
+      signer: this.signer,
+      account: identity.getPrincipal(),
+      agent,
     });
   }
 
@@ -178,7 +188,6 @@ export class IISignerAdapter extends BaseSignerAdapter<IIAdapterConfig> {
               owner: identity.getPrincipal().toText(),
               subaccount: null,
             };
-            this.identity = identity;
             await this.initAgentAndSigner(identity);
 
             this.setState(Status.CONNECTED);
@@ -250,6 +259,7 @@ export class IISignerAdapter extends BaseSignerAdapter<IIAdapterConfig> {
   protected cleanupInternal(): void {
     this.authClient = null;
     this.agent = null;
+    this.#signerAgent = null;
   }
 
   /**
@@ -267,5 +277,6 @@ export class IISignerAdapter extends BaseSignerAdapter<IIAdapterConfig> {
       this.authClient = null;
     }
     this.agent = null;
+    this.#signerAgent = null;
   }
 }

--- a/src/cashier_frontend_new/src/modules/auth/state/auth.svelte.ts
+++ b/src/cashier_frontend_new/src/modules/auth/state/auth.svelte.ts
@@ -234,14 +234,15 @@ export const authState = {
       return null;
     }
 
-    if (canisterId instanceof Principal) {
-      canisterId = canisterId.toText();
+    // Build SignerAgent from adapter's Signer - routes Actor calls through Signer -> IIChannel
+    const signerAgent = (pnp.provider as BaseSignerAdapter).getSignerAgent();
+    if (!signerAgent) {
+      throw new Error("Signer not available after connect");
     }
 
-    // pnp is initialized and user is logged in, return actor with current identity
-    return pnp.getActor({
+    return Actor.createActor(idlFactory, {
+      agent: signerAgent,
       canisterId,
-      idl: idlFactory,
     });
   },
 

--- a/src/cashier_frontend_new/src/modules/bitcoin/services/ckBTCMinterService.ts
+++ b/src/cashier_frontend_new/src/modules/bitcoin/services/ckBTCMinterService.ts
@@ -21,10 +21,11 @@ export class CkBTCMinterService {
    * Create and return the ckBTC Minter actor for the current user.
    * @returns
    */
-  #getActor(): ckBTCMinter._SERVICE | null {
+  #getActor(options?: { anonymous?: boolean }): ckBTCMinter._SERVICE | null {
     return authState.buildActor({
       canisterId: this.#canisterId,
       idlFactory: ckBTCMinter.idlFactory,
+      options,
     });
   }
 
@@ -33,9 +34,9 @@ export class CkBTCMinterService {
    * @returns fee as bigint
    */
   async getDepositFee(): Promise<bigint> {
-    const actor = this.#getActor();
+    const actor = this.#getActor({ anonymous: true });
     if (!actor) {
-      throw new Error("User is not authenticated");
+      throw new Error("Failed to create actor");
     }
     return actor.get_deposit_fee();
   }
@@ -46,9 +47,9 @@ export class CkBTCMinterService {
    * @returns WithdrawalFee
    */
   async getWithdrawalFee(amount: bigint): Promise<WithdrawalFee> {
-    const actor = this.#getActor();
+    const actor = this.#getActor({ anonymous: true });
     if (!actor) {
-      throw new Error("User is not authenticated");
+      throw new Error("Failed to create actor");
     }
     const withdrawalFee = await actor.estimate_withdrawal_fee({
       amount: [amount],
@@ -61,9 +62,9 @@ export class CkBTCMinterService {
    * @returns MinterInfo
    */
   async getMinterInfo(): Promise<MinterInfo> {
-    const actor = this.#getActor();
+    const actor = this.#getActor({ anonymous: true });
     if (!actor) {
-      throw new Error("User is not authenticated");
+      throw new Error("Failed to create actor");
     }
     return actor.get_minter_info();
   }

--- a/src/cashier_frontend_new/src/modules/token/services/icpLedger.spec.ts
+++ b/src/cashier_frontend_new/src/modules/token/services/icpLedger.spec.ts
@@ -88,6 +88,7 @@ describe("IcpLedgerService", () => {
       expect(mockBuildActor).toHaveBeenCalledWith({
         canisterId: "ryjl3-tyaaa-aaaaa-aaaba-cai",
         idlFactory: expect.any(Function),
+        options: { anonymous: true },
       });
       expect(mockIcrc1BalanceOf).toHaveBeenCalledWith({
         owner: Principal.fromText("aaaaa-aa"),
@@ -96,11 +97,11 @@ describe("IcpLedgerService", () => {
       expect(balance).toBe(expectedBalance);
     });
 
-    it("should throw when actor is null (not authenticated)", async () => {
+    it("should throw when actor is null", async () => {
       mockBuildActor.mockReturnValue(null);
 
       await expect(service.getBalance()).rejects.toThrow(
-        "User is not authenticated",
+        "Failed to create actor",
       );
     });
 

--- a/src/cashier_frontend_new/src/modules/token/services/icpLedger.ts
+++ b/src/cashier_frontend_new/src/modules/token/services/icpLedger.ts
@@ -24,10 +24,11 @@ export class IcpLedgerService {
    * @returns Authenticated ICP Ledger actor
    * @throws Error if the user is not authenticated
    */
-  #getActor(): icpLedger._SERVICE | null {
+  #getActor(options?: { anonymous?: boolean }): icpLedger._SERVICE | null {
     return authState.buildActor({
       canisterId: this.#canisterId,
       idlFactory: icpLedger.idlFactory,
+      options,
     });
   }
 
@@ -53,9 +54,9 @@ export class IcpLedgerService {
    * @throws Error if the user is not authenticated or balance retrieval fails.
    */
   public async getBalance(): Promise<bigint> {
-    const actor = this.#getActor();
+    const actor = this.#getActor({ anonymous: true });
     if (!actor) {
-      throw new Error("User is not authenticated");
+      throw new Error("Failed to create actor");
     }
     const account: Account = this.#getAccount();
     return await actor.icrc1_balance_of(account);

--- a/src/cashier_frontend_new/src/modules/token/services/icrcLedger.spec.ts
+++ b/src/cashier_frontend_new/src/modules/token/services/icrcLedger.spec.ts
@@ -85,6 +85,7 @@ describe("IcrcLedgerService", () => {
       expect(mockBuildActor).toHaveBeenCalledWith({
         canisterId: mockToken.address,
         idlFactory: expect.any(Function),
+        options: { anonymous: true },
       });
       expect(mockIcrc1BalanceOf).toHaveBeenCalledWith({
         owner: Principal.fromText("aaaaa-aa"),
@@ -93,11 +94,11 @@ describe("IcrcLedgerService", () => {
       expect(balance).toBe(expectedBalance);
     });
 
-    it("should throw when actor is null (not authenticated)", async () => {
+    it("should throw when actor is null", async () => {
       mockBuildActor.mockReturnValue(null);
 
       await expect(service.getBalance()).rejects.toThrow(
-        "User is not authenticated",
+        "Failed to create actor",
       );
     });
 

--- a/src/cashier_frontend_new/src/modules/token/services/icrcLedger.ts
+++ b/src/cashier_frontend_new/src/modules/token/services/icrcLedger.ts
@@ -21,10 +21,11 @@ export class IcrcLedgerService {
    * @returns Authenticated Icrc Ledger actor
    * @throws Error if the user is not authenticated
    */
-  #getActor(): icrcLedger._SERVICE | null {
+  #getActor(options?: { anonymous?: boolean }): icrcLedger._SERVICE | null {
     return authState.buildActor({
       canisterId: this.#canisterId,
       idlFactory: icrcLedger.idlFactory,
+      options,
     });
   }
 
@@ -50,9 +51,9 @@ export class IcrcLedgerService {
    * @throws Error if the user is not authenticated or balance retrieval fails.
    */
   public async getBalance(): Promise<bigint> {
-    const actor = this.#getActor();
+    const actor = this.#getActor({ anonymous: true });
     if (!actor) {
-      throw new Error("User is not authenticated");
+      throw new Error("Failed to create actor");
     }
     const account: icrcLedger.Account = this.#getAccount();
     return await actor.icrc1_balance_of(account);

--- a/src/cashier_frontend_new/src/modules/wallet/services/icrc7Service.ts
+++ b/src/cashier_frontend_new/src/modules/wallet/services/icrc7Service.ts
@@ -22,10 +22,11 @@ export class Icrc7Service {
    * @returns Authenticated Icrc Ledger actor
    * @throws Error if the user is not authenticated
    */
-  #getActor(): icrc7Ledger._SERVICE | null {
+  #getActor(options?: { anonymous?: boolean }): icrc7Ledger._SERVICE | null {
     return authState.buildActor({
       canisterId: this.#canisterId,
       idlFactory: icrc7Ledger.idlFactory,
+      options,
     });
   }
 
@@ -35,9 +36,9 @@ export class Icrc7Service {
    * @returns NFTMetadata
    */
   public async getTokenMetadata(tokenId: bigint): Promise<NFTMetadata> {
-    const actor = this.#getActor();
+    const actor = this.#getActor({ anonymous: true });
     if (!actor) {
-      throw new Error("User is not authenticated");
+      throw new Error("Failed to create actor");
     }
     const res = await actor.icrc7_token_metadata([tokenId]);
     return NFTMetadataMapper.fromIcrc7LedgerTokenMetadata(res[0]);
@@ -48,9 +49,9 @@ export class Icrc7Service {
    * @returns CollectionMetadata
    */
   public async getCollectionMetadata(): Promise<CollectionMetadata> {
-    const actor = this.#getActor();
+    const actor = this.#getActor({ anonymous: true });
     if (!actor) {
-      throw new Error("User is not authenticated");
+      throw new Error("Failed to create actor");
     }
     const res = await actor.icrc7_collection_metadata();
     return CollectionMetadataMapper.fromIcrc7LedgerCollectionMetadata(res);


### PR DESCRIPTION
Ticket https://app.clickup.com/t/869c34dbw

Current flow:
Frontend Service → Actor → HttpAgent → Identity 

Updated flow:
Frontend Service → Actor → SignerAgent (provided by SignerAdapter) → Transport → IIChannel → HttpAgent → Identity