### PR TITLE
[869c2v9gt] add token manager permission and endpoint

### DIFF
--- a/src/cashier_frontend_new/src/lib/generated/icp_ledger_canister/icp_ledger_canister.did.d.ts
+++ b/src/cashier_frontend_new/src/lib/generated/icp_ledger_canister/icp_ledger_canister.did.d.ts
@@ -323,6 +323,7 @@ export type TextAccountIdentifier = string;
  */
 export interface TimeStamp { 'timestamp_nanos' : bigint }
 /**
+ * This is the official Ledger interface that is guaranteed to be backward compatible.
  * Amount of tokens, measured in 10^-8 of a token.
  */
 export interface Tokens { 'e8s' : bigint }

--- a/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.d.ts
+++ b/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.d.ts
@@ -106,7 +106,8 @@ export interface LogServiceSettings {
   'max_record_length' : [] | [bigint],
 }
 export interface Nft { 'token_id' : bigint, 'collection_id' : Principal }
-export type Permission = { 'Admin' : null };
+export type Permission = { 'TokenManager' : null } |
+  { 'Admin' : null };
 export interface RegistryStats {
   'total_enabled_default' : bigint,
   'total_tokens' : bigint,
@@ -252,13 +253,6 @@ export interface _SERVICE {
     Result_6
   >,
   /**
-   * Admin override for a token's supported standards
-   */
-  'admin_update_token_standards' : ActorMethod<
-    [UpdateTokenStandardsInput],
-    Result_3
-  >,
-  /**
    * Returns the build data of the canister.
    */
   'get_canister_build_data' : ActorMethod<[], BuildData>,
@@ -270,6 +264,13 @@ export interface _SERVICE {
    * Lists the tokens in the registry for the caller
    */
   'list_tokens' : ActorMethod<[], Result_5>,
+  /**
+   * Admin override for a token's supported standards
+   */
+  'token_manager_update_token_standards' : ActorMethod<
+    [UpdateTokenStandardsInput],
+    Result_3
+  >,
   /**
    * Adds a new NFT to the user's collection
    * # Arguments

--- a/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.js
+++ b/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.js
@@ -117,14 +117,13 @@ export const idlFactory = ({ IDL }) => {
     'perference' : IDL.Opt(UserPreference),
   });
   const Result_5 = IDL.Variant({ 'Ok' : TokenListResponse, 'Err' : IDL.Text });
-  const Permission = IDL.Variant({ 'Admin' : IDL.Null });
+  const Permission = IDL.Variant({
+    'TokenManager' : IDL.Null,
+    'Admin' : IDL.Null,
+  });
   const Result_6 = IDL.Variant({
     'Ok' : IDL.Vec(Permission),
     'Err' : CanisterError,
-  });
-  const UpdateTokenStandardsInput = IDL.Record({
-    'token_id' : TokenId,
-    'supported_standards' : IDL.Vec(IcrcStandard),
   });
   const BuildData = IDL.Record({
     'rustc_semver' : IDL.Text,
@@ -137,6 +136,10 @@ export const idlFactory = ({ IDL }) => {
     'build_timestamp' : IDL.Text,
     'git_sha' : IDL.Text,
     'git_commit_timestamp' : IDL.Text,
+  });
+  const UpdateTokenStandardsInput = IDL.Record({
+    'token_id' : TokenId,
+    'supported_standards' : IDL.Vec(IcrcStandard),
   });
   const Nft = IDL.Record({
     'token_id' : IDL.Nat,
@@ -268,14 +271,14 @@ export const idlFactory = ({ IDL }) => {
         [Result_6],
         [],
       ),
-    'admin_update_token_standards' : IDL.Func(
+    'get_canister_build_data' : IDL.Func([], [BuildData], ['query']),
+    'is_inspect_message_enabled' : IDL.Func([], [IDL.Bool], ['query']),
+    'list_tokens' : IDL.Func([], [Result_5], ['query']),
+    'token_manager_update_token_standards' : IDL.Func(
         [UpdateTokenStandardsInput],
         [Result_3],
         [],
       ),
-    'get_canister_build_data' : IDL.Func([], [BuildData], ['query']),
-    'is_inspect_message_enabled' : IDL.Func([], [IDL.Bool], ['query']),
-    'list_tokens' : IDL.Func([], [Result_5], ['query']),
     'user_add_nft' : IDL.Func([AddUserNftInput], [Result_7], []),
     'user_add_token' : IDL.Func([AddTokenInput], [Result_3], []),
     'user_add_token_batch' : IDL.Func([AddTokensInput], [Result_3], []),

--- a/src/integration_tests/tests/token_storage/admin.rs
+++ b/src/integration_tests/tests/token_storage/admin.rs
@@ -1,7 +1,4 @@
-use token_storage_types::{
-    auth::Permission,
-    token::{ChainTokenDetails, IcrcStandard, UpdateTokenStandardsInput},
-};
+use token_storage_types::auth::Permission;
 
 use crate::utils::{principal::TestUser, with_pocket_ic_context};
 
@@ -117,107 +114,6 @@ async fn should_not_allow_user_to_set_and_remove_permissions() {
                 .to_string()
                 .contains("NotAuthorized")
         );
-
-        Ok(())
-    })
-    .await
-    .unwrap();
-}
-
-#[tokio::test]
-async fn should_allow_admin_to_update_token_standards() {
-    with_pocket_ic_context::<_, ()>(async move |ctx| {
-        // Arrange
-        let admin = TestUser::TokenStorageAdmin.get_principal();
-        let admin_client = ctx.new_token_storage_client(admin);
-
-        // Get ICP token from registry
-        let tokens = admin_client.list_tokens().await.unwrap().unwrap();
-        let icp_token = tokens.tokens.iter().find(|t| t.symbol == "ICP").unwrap();
-        let token_id = icp_token.id.clone();
-
-        // Assert BEFORE: token should have default standards (ICRC1 + ICRC2 from fixture)
-        assert!(!icp_token.details.supports_standard(&IcrcStandard::ICRC3));
-
-        // Act: update standards to include ICRC-3
-        let input = UpdateTokenStandardsInput {
-            token_id: token_id.clone(),
-            supported_standards: vec![
-                IcrcStandard::ICRC1,
-                IcrcStandard::ICRC2,
-                IcrcStandard::ICRC3,
-            ],
-        };
-        admin_client
-            .admin_update_token_standards(input)
-            .await
-            .unwrap()
-            .unwrap();
-
-        // Assert AFTER: re-fetch and verify standards changed
-        let tokens_after = admin_client.list_tokens().await.unwrap().unwrap();
-        let icp_after = tokens_after
-            .tokens
-            .iter()
-            .find(|t| t.symbol == "ICP")
-            .unwrap();
-
-        // Verify the new standards are exactly what we set
-        match &icp_after.details {
-            ChainTokenDetails::IC {
-                supported_standards,
-                ..
-            } => {
-                assert_eq!(
-                    supported_standards,
-                    &vec![
-                        IcrcStandard::ICRC1,
-                        IcrcStandard::ICRC2,
-                        IcrcStandard::ICRC3
-                    ]
-                );
-            }
-        }
-
-        // Verify helper methods work correctly on updated token
-        assert!(icp_after.details.supports_icrc2());
-        assert!(icp_after.details.supports_standard(&IcrcStandard::ICRC3));
-
-        Ok(())
-    })
-    .await
-    .unwrap();
-}
-
-#[tokio::test]
-async fn should_not_allow_user_to_update_token_standards() {
-    with_pocket_ic_context::<_, ()>(async move |ctx| {
-        // Arrange
-        let admin = TestUser::TokenStorageAdmin.get_principal();
-        let admin_client = ctx.new_token_storage_client(admin);
-        let user = TestUser::User1.get_principal();
-        let user_client = ctx.new_token_storage_client(user);
-
-        // Disable inspect message to test direct endpoint behavior
-        admin_client
-            .admin_inspect_message_enable(false)
-            .await
-            .unwrap()
-            .unwrap();
-
-        // Get ICP token
-        let tokens = admin_client.list_tokens().await.unwrap().unwrap();
-        let icp_token = tokens.tokens.iter().find(|t| t.symbol == "ICP").unwrap();
-
-        // Act: user tries to update standards
-        let input = UpdateTokenStandardsInput {
-            token_id: icp_token.id.clone(),
-            supported_standards: vec![IcrcStandard::ICRC1, IcrcStandard::ICRC2],
-        };
-        let result = user_client.admin_update_token_standards(input).await;
-
-        // Assert: should fail with NotAuthorized
-        assert!(result.unwrap_err().to_string().contains("NotAuthorized"));
 
         Ok(())
     })

--- a/src/integration_tests/tests/token_storage/mod.rs
+++ b/src/integration_tests/tests/token_storage/mod.rs
@@ -7,6 +7,7 @@ pub mod bitcoin;
 pub mod inspect_message;
 pub mod nft;
 pub mod token;
+pub mod token_manager;
 
 /// Tests that the token storage canister can be deployed.
 #[tokio::test]

--- a/src/integration_tests/tests/token_storage/token_manager.rs
+++ b/src/integration_tests/tests/token_storage/token_manager.rs
@@ -1,0 +1,250 @@
+// Copyright (c) 2025 Cashier Protocol Labs
+// Licensed under the MIT License (see LICENSE file in the project root)
+
+use token_storage_types::{
+    auth::Permission,
+    token::{ChainTokenDetails, IcrcStandard, UpdateTokenStandardsInput},
+};
+
+use crate::utils::{principal::TestUser, with_pocket_ic_context};
+
+/// Test fixture for TokenManager permission setup
+struct TokenManagerFixture {
+    admin: candid::Principal,
+    token_manager: candid::Principal,
+}
+
+impl TokenManagerFixture {
+    /// Creates a new fixture with admin granting TokenManager permission to another principal
+    async fn new(ctx: &crate::utils::PocketIcTestContext) -> Self {
+        let admin = TestUser::TokenStorageAdmin.get_principal();
+        let token_manager = TestUser::User1.get_principal();
+
+        let admin_client = ctx.new_token_storage_client(admin);
+
+        // Grant TokenManager permission to User1
+        admin_client
+            .admin_permissions_add(token_manager, vec![Permission::TokenManager])
+            .await
+            .unwrap()
+            .unwrap();
+
+        Self {
+            admin,
+            token_manager,
+        }
+    }
+}
+
+/// Test: Admin can update token standards
+#[tokio::test]
+async fn should_allow_admin_to_update_token_standards() {
+    with_pocket_ic_context::<_, ()>(async move |ctx| {
+        // Arrange
+        let admin = TestUser::TokenStorageAdmin.get_principal();
+        let admin_client = ctx.new_token_storage_client(admin);
+
+        // Get ICP token from registry
+        let tokens = admin_client.list_tokens().await.unwrap().unwrap();
+        let icp_token = tokens.tokens.iter().find(|t| t.symbol == "ICP").unwrap();
+        let token_id = icp_token.id.clone();
+
+        // Assert BEFORE: token should have default standards (ICRC1 + ICRC2 from fixture)
+        assert!(!icp_token.details.supports_standard(&IcrcStandard::ICRC3));
+
+        // Act: update standards to include ICRC-3
+        let input = UpdateTokenStandardsInput {
+            token_id: token_id.clone(),
+            supported_standards: vec![
+                IcrcStandard::ICRC1,
+                IcrcStandard::ICRC2,
+                IcrcStandard::ICRC3,
+            ],
+        };
+        admin_client
+            .token_manager_update_token_standards(input)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Assert AFTER: re-fetch and verify standards changed
+        let tokens_after = admin_client.list_tokens().await.unwrap().unwrap();
+        let icp_after = tokens_after
+            .tokens
+            .iter()
+            .find(|t| t.symbol == "ICP")
+            .unwrap();
+
+        // Verify the new standards are exactly what we set
+        match &icp_after.details {
+            ChainTokenDetails::IC {
+                supported_standards,
+                ..
+            } => {
+                assert_eq!(
+                    supported_standards,
+                    &vec![
+                        IcrcStandard::ICRC1,
+                        IcrcStandard::ICRC2,
+                        IcrcStandard::ICRC3
+                    ]
+                );
+            }
+        }
+
+        // Verify helper methods work correctly on updated token
+        assert!(icp_after.details.supports_icrc2());
+        assert!(icp_after.details.supports_standard(&IcrcStandard::ICRC3));
+
+        Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+/// Test: TokenManager can update token standards
+#[tokio::test]
+async fn should_allow_token_manager_to_update_token_standards() {
+    with_pocket_ic_context::<_, ()>(async move |ctx| {
+        // Arrange
+        let fixture = TokenManagerFixture::new(ctx).await;
+        let token_manager_client = ctx.new_token_storage_client(fixture.token_manager);
+
+        // Get ICP token from registry
+        let tokens = token_manager_client.list_tokens().await.unwrap().unwrap();
+        let icp_token = tokens.tokens.iter().find(|t| t.symbol == "ICP").unwrap();
+        let token_id = icp_token.id.clone();
+
+        // Assert BEFORE: token should not have ICRC3
+        assert!(!icp_token.details.supports_standard(&IcrcStandard::ICRC3));
+
+        // Act: TokenManager updates standards
+        let input = UpdateTokenStandardsInput {
+            token_id: token_id.clone(),
+            supported_standards: vec![
+                IcrcStandard::ICRC1,
+                IcrcStandard::ICRC2,
+                IcrcStandard::ICRC3,
+            ],
+        };
+        token_manager_client
+            .token_manager_update_token_standards(input)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Assert AFTER: verify standards were updated
+        let tokens_after = token_manager_client.list_tokens().await.unwrap().unwrap();
+        let icp_after = tokens_after
+            .tokens
+            .iter()
+            .find(|t| t.symbol == "ICP")
+            .unwrap();
+
+        assert!(icp_after.details.supports_standard(&IcrcStandard::ICRC3));
+
+        Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+/// Test: User cannot update token standards
+#[tokio::test]
+async fn should_not_allow_user_to_update_token_standards() {
+    with_pocket_ic_context::<_, ()>(async move |ctx| {
+        // Arrange
+        let admin = TestUser::TokenStorageAdmin.get_principal();
+        let admin_client = ctx.new_token_storage_client(admin);
+        let user = TestUser::User2.get_principal();
+        let user_client = ctx.new_token_storage_client(user);
+
+        // Disable inspect message to test direct endpoint behavior
+        admin_client
+            .admin_inspect_message_enable(false)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Get ICP token
+        let tokens = admin_client.list_tokens().await.unwrap().unwrap();
+        let icp_token = tokens.tokens.iter().find(|t| t.symbol == "ICP").unwrap();
+
+        // Act: user tries to update standards
+        let input = UpdateTokenStandardsInput {
+            token_id: icp_token.id.clone(),
+            supported_standards: vec![IcrcStandard::ICRC1, IcrcStandard::ICRC2],
+        };
+        let result = user_client
+            .token_manager_update_token_standards(input)
+            .await;
+
+        // Assert: should fail with NotAuthorized
+        assert!(result.is_ok());
+        let inner_result = result.unwrap();
+        assert!(inner_result.is_err());
+        assert!(inner_result.unwrap_err().contains("NotAuthorized"));
+
+        Ok(())
+    })
+    .await
+    .unwrap();
+}
+
+/// Test: Verify all 3 roles (Admin, TokenManager, User) have correct access
+#[tokio::test]
+async fn should_verify_three_role_access_control() {
+    with_pocket_ic_context::<_, ()>(async move |ctx| {
+        // Arrange
+        let fixture = TokenManagerFixture::new(ctx).await;
+        let user = TestUser::User3.get_principal();
+        let user_client = ctx.new_token_storage_client(user);
+
+        let admin_client = ctx.new_token_storage_client(fixture.admin);
+        let token_manager_client = ctx.new_token_storage_client(fixture.token_manager);
+
+        // Disable inspect message for direct testing
+        admin_client
+            .admin_inspect_message_enable(false)
+            .await
+            .unwrap()
+            .unwrap();
+
+        // Get ICP token
+        let tokens = admin_client.list_tokens().await.unwrap().unwrap();
+        let icp_token = tokens.tokens.iter().find(|t| t.symbol == "ICP").unwrap();
+        let token_id = icp_token.id.clone();
+
+        let input = UpdateTokenStandardsInput {
+            token_id: token_id.clone(),
+            supported_standards: vec![IcrcStandard::ICRC1, IcrcStandard::ICRC2],
+        };
+
+        // Act & Assert: Admin can update
+        let admin_result = admin_client
+            .token_manager_update_token_standards(input.clone())
+            .await;
+        assert!(admin_result.is_ok());
+        assert!(admin_result.unwrap().is_ok());
+
+        // Act & Assert: TokenManager can update
+        let token_manager_result = token_manager_client
+            .token_manager_update_token_standards(input.clone())
+            .await;
+        assert!(token_manager_result.is_ok());
+        assert!(token_manager_result.unwrap().is_ok());
+
+        // Act & Assert: User cannot update
+        let user_result = user_client
+            .token_manager_update_token_standards(input)
+            .await;
+        assert!(user_result.is_ok());
+        let inner_result = user_result.unwrap();
+        assert!(inner_result.is_err());
+        assert!(inner_result.unwrap_err().contains("NotAuthorized"));
+
+        Ok(())
+    })
+    .await
+    .unwrap();
+}

--- a/src/token_storage/src/api/admin.rs
+++ b/src/token_storage/src/api/admin.rs
@@ -8,10 +8,7 @@ use log::{debug, info};
 use token_storage_types::{
     TokenId,
     error::CanisterError,
-    token::{
-        RegistryStats, TokenDto, TokenListResponse, TokenRegistryMetadata,
-        UpdateTokenStandardsInput, UserTokens,
-    },
+    token::{RegistryStats, TokenDto, TokenListResponse, TokenRegistryMetadata, UserTokens},
 };
 
 use crate::{api::state::get_state, build_data::canister_build_data, services::auth::Permission};
@@ -132,22 +129,6 @@ pub fn admin_initialize_registry() -> Result<(), String> {
         .expect("Should be able to delete registry");
 
     Ok(())
-}
-
-/// Admin override for a token's supported standards
-#[update]
-pub fn admin_update_token_standards(input: UpdateTokenStandardsInput) -> Result<(), String> {
-    info!("[admin_update_token_standards]");
-    debug!("[admin_update_token_standards] input: {input:?}");
-
-    let state = get_state();
-    let caller = msg_caller();
-    state
-        .auth_service
-        .must_have_permission(&caller, Permission::Admin);
-
-    let mut registry = state.token_registry;
-    registry.update_token_standards(input.token_id, input.supported_standards)
 }
 
 #[query]

--- a/src/token_storage/src/api/inspect_message.rs
+++ b/src/token_storage/src/api/inspect_message.rs
@@ -21,6 +21,9 @@ fn inspect_messages() {
         method if method.starts_with("admin_") => state
             .auth_service
             .check_has_permission(&caller, Permission::Admin),
+        method if method.starts_with("token_manager") => state
+            .auth_service
+            .check_has_any_permission(&caller, &[Permission::Admin, Permission::TokenManager]),
         method if method.starts_with("user_") => {
             if caller == Principal::anonymous() {
                 Err(AuthError::AnonimousUserNotAllowed)

--- a/src/token_storage/src/api/mod.rs
+++ b/src/token_storage/src/api/mod.rs
@@ -8,6 +8,7 @@ mod inspect_message;
 pub mod nft;
 mod state;
 pub mod token;
+pub mod token_manager;
 
 use candid::Principal;
 use cashier_common::build_data::BuildData;

--- a/src/token_storage/src/api/token_manager.rs
+++ b/src/token_storage/src/api/token_manager.rs
@@ -1,0 +1,24 @@
+use ic_cdk::{api::msg_caller, update};
+use log::{debug, info};
+use token_storage_types::{auth::Permission, token::UpdateTokenStandardsInput};
+
+use crate::api::state::get_state;
+
+/// Admin override for a token's supported standards
+#[update]
+pub fn token_manager_update_token_standards(
+    input: UpdateTokenStandardsInput,
+) -> Result<(), String> {
+    info!("[admin_update_token_standards]");
+    debug!("[admin_update_token_standards] input: {input:?}");
+
+    let state = get_state();
+    let caller = msg_caller();
+    state
+        .auth_service
+        .check_has_any_permission(&caller, &[Permission::Admin, Permission::TokenManager])
+        .map_err(|e| format!("{e:?}"))?;
+
+    let mut registry = state.token_registry;
+    registry.update_token_standards(input.token_id, input.supported_standards)
+}

--- a/src/token_storage/src/api/token_manager.rs
+++ b/src/token_storage/src/api/token_manager.rs
@@ -4,13 +4,13 @@ use token_storage_types::{auth::Permission, token::UpdateTokenStandardsInput};
 
 use crate::api::state::get_state;
 
-/// Admin override for a token's supported standards
+/// Override for a token's supported standards
 #[update]
 pub fn token_manager_update_token_standards(
     input: UpdateTokenStandardsInput,
 ) -> Result<(), String> {
-    info!("[admin_update_token_standards]");
-    debug!("[admin_update_token_standards] input: {input:?}");
+    info!("[token_manager_update_token_standards]");
+    debug!("[token_manager_update_token_standards] input: {input:?}");
 
     let state = get_state();
     let caller = msg_caller();

--- a/src/token_storage_client/src/client.rs
+++ b/src/token_storage_client/src/client.rs
@@ -181,12 +181,12 @@ impl<C: CanisterClient> TokenStorageClient<C> {
     }
 
     /// Admin override for a token's supported standards
-    pub async fn admin_update_token_standards(
+    pub async fn token_manager_update_token_standards(
         &self,
         input: UpdateTokenStandardsInput,
     ) -> CanisterClientResult<Result<(), String>> {
         self.client
-            .update("admin_update_token_standards", (input,))
+            .update("token_manager_update_token_standards", (input,))
             .await
     }
 }

--- a/src/token_storage_types/src/auth.rs
+++ b/src/token_storage_types/src/auth.rs
@@ -8,4 +8,5 @@ use serde::Deserialize;
 pub enum Permission {
     /// Admin of the canister
     Admin,
+    TokenManager,
 }

--- a/src/token_storage_types/src/auth.rs
+++ b/src/token_storage_types/src/auth.rs
@@ -8,5 +8,6 @@ use serde::Deserialize;
 pub enum Permission {
     /// Admin of the canister
     Admin,
+    /// Manager of token-related operations
     TokenManager,
 }


### PR DESCRIPTION
Ticket: https://app.clickup.com/t/869c2v9gt
Updates:

- Add new Permission for TokenManager
- Upgrade endpoint `admin_update_token_standards` to `token_manager_update_token_standards` to allow both Admin and TokenManager
- Update tests

Note:
To add new token manager run with admin identity
```bash
 dfx canister call <canister-id> admin_permissions_add \
  "(principal \"<principal>\", vec { variant { TokenManager } })" \
```