### PR TITLE
Hotfix: Update actions/checkout@v4 config 

### DIFF
--- a/.github/workflows/fast-forward-merge.yml
+++ b/.github/workflows/fast-forward-merge.yml
@@ -22,6 +22,8 @@ jobs:
       # Step 1: Checkout repo so scripts are available for all steps
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # fetch full history + all branches
 
       # Step 2: Check all CI checks passed
       - name: Check all CI checks passed


### PR DESCRIPTION
## Root Cause

The `actions/checkout@v4` step was added to make local scripts (`.github/scripts/*.js`) available to the workflow. By default, `actions/checkout@v4` only does a shallow clone of the triggered branch (`dev`) with `fetch-depth: 1`, so `origin/staging` was never fetched.

When `sequoia-pgp/fast-forward@v1` ran after it, it couldn't resolve `origin/staging` to a real commit SHA, causing the error:

```
fatal: ambiguous argument 'origin/staging': unknown revision or path
```

Previously this worked because the `checkout` step didn't exist — `sequoia-pgp/fast-forward@v1` set up its own git environment and fetched all branches itself.

## Fix

Add `fetch-depth: 0` to the checkout step so all branches including `staging` are fetched:

```yaml
- name: Checkout repository
  uses: actions/checkout@v4
  with:
    fetch-depth: 0
```