### PR TITLE
Hotfix: use TokenStorageArgs enum for init/upgrade Candid encoding

### DIFF
--- a/.github/workflows/orbit-backend-deploy.yml
+++ b/.github/workflows/orbit-backend-deploy.yml
@@ -156,7 +156,14 @@ jobs:
           ckbtc_minter_id=${{ vars.CKBTC_MINTER_ID }}
           token_storage_canister_id=${{ vars.TOKEN_STORAGE_CANISTER_ID }}
           just build_backend_args "$owner" "$token_storage_canister_id" "${{ steps.log_filter.outputs.filter }}" backend_args.txt
-          just build_token_storage_args "$owner" "${{ steps.log_filter.outputs.filter }}" "$ckbtc_minter_id" token_storage_args.txt
+
+          # Use init or upgrade template based on deploy mode
+          if [ "${{ env.MODE }}" = "install" ] || [ "${{ env.MODE }}" = "reinstall" ]; then
+            just build_token_storage_init_args "$owner" "${{ steps.log_filter.outputs.filter }}" "$ckbtc_minter_id" token_storage_args.txt
+          else
+            just build_token_storage_upgrade_args "$ckbtc_minter_id" token_storage_args.txt
+          fi
+
           echo "Backend args:"
           cat backend_args.txt
           echo ""

--- a/just/dfx.just
+++ b/just/dfx.just
@@ -202,17 +202,17 @@ dfx_deploy_backend owner network="" log_filter="global,cashier=debug":
       token_storage_canister_id=principal \"${TOKEN_STORAGE_CANISTER_ID}\";
   })" {{network}}
 
-# Deploys the token_storage canister
-# params 
+# Deploys the token_storage canister (init mode - install/reinstall)
+# params
 # owner: principal id of the owner
 # network: dfx network flag, e.g. --network=dev
 # log_filter: log filter string (default for local and dev)
 [private]
-dfx_deploy_token_storage owner network="" log_filter="global,cashier=debug,token_storage=debug" mode="":
+dfx_deploy_token_storage owner network="" log_filter="global,cashier=debug,token_storage=debug":
   #!/usr/bin/env bash
   set -e
 
-  dfx deploy token_storage --argument "(record {
+  dfx deploy token_storage --argument "(variant { Init = record {
       log_settings=opt record { enable_console=opt true; in_memory_records=opt 10000; log_filter=opt \"{{log_filter}}\"; };
       owner=principal \"{{owner}}\";
       tokens = opt vec {
@@ -270,7 +270,20 @@ dfx_deploy_token_storage owner network="" log_filter="global,cashier=debug,token
         };
       };
       ckbtc_minter_id = principal \"{{CKBTC_MINTER_ID}}\";
-  })" {{network}} {{mode}} --yes
+  }})" {{network}} --yes
+
+# Upgrades the token_storage canister
+# params
+# network: dfx network flag, e.g. --network=dev
+[private]
+dfx_upgrade_token_storage network="":
+  #!/usr/bin/env bash
+  set -e
+
+  dfx deploy token_storage --argument "(variant { Upgrade = record {
+      ckbtc_minter_id = principal \"{{CKBTC_MINTER_ID}}\";
+      tokens = null;
+  }})" {{network}} --mode=upgrade --yes
 
 # Deploy Gate canister
 # params:
@@ -607,4 +620,4 @@ dfx_mainnet_deploy_token_storage:
   set -e
 
   export OWNER=$(dfx identity get-principal)
-  just dfx_deploy_token_storage "${OWNER}" "--network=ic" "global,cashier=debug,token_storage=debug" "--mode=upgrade"
+  just dfx_upgrade_token_storage "--network=ic"

--- a/just/orbit.just
+++ b/just/orbit.just
@@ -70,15 +70,30 @@ build_backend_args owner token_storage_canister_id log_filter file_name:
     scripts/args/backend_args.template \
     | tr -d '\n' | tr -s ' ' > {{file_name}}
 
-# Build token_storage canister args and save to file
+# Build token_storage canister INIT args (for install/reinstall mode)
+# Usage: just build_token_storage_init_args <owner_principal> <log_filter> <ckbtc_minter_principal> <output_file>
+# Example: just build_token_storage_init_args "useor-pyaaa-aaaad-ac2ya-cai" "global,cashier=debug,token_storage=debug" "mqygn-kiaaa-aaaar-qaadq-cai" token_storage_args.txt
 [group('orbit')]
-build_token_storage_args owner log_filter ckbtc_minter_id file_name:
+build_token_storage_init_args owner log_filter ckbtc_minter_id file_name:
   #!/usr/bin/env bash
   sed \
     -e 's/__OWNER__/{{owner}}/g' \
     -e 's/__LOG_FILTER__/{{log_filter}}/g' \
     -e 's/__CKBTC_MINTER_ID__/{{ckbtc_minter_id}}/g' \
-    scripts/args/token_storage_args.template \
+    scripts/args/token_storage_init_args.template \
+    | sed -e '/__TOKENS__/r scripts/args/token_storage_tokens.template' -e '/__TOKENS__/d' \
+    | tr -d '\n' | tr -s ' ' > {{file_name}}
+
+# Build token_storage canister UPGRADE args (for upgrade mode)
+# Usage: just build_token_storage_upgrade_args <ckbtc_minter_principal> <output_file>
+# Example: just build_token_storage_upgrade_args "mqygn-kiaaa-aaaar-qaadq-cai" token_storage_args.txt
+[group('orbit')]
+build_token_storage_upgrade_args ckbtc_minter_id file_name:
+  #!/usr/bin/env bash
+  sed \
+    -e 's/__CKBTC_MINTER_ID__/{{ckbtc_minter_id}}/g' \
+    scripts/args/token_storage_upgrade_args.template \
+    | sed -e '/__TOKENS__/r scripts/args/token_storage_tokens.template' -e '/__TOKENS__/d' \
     | tr -d '\n' | tr -s ' ' > {{file_name}}
 
 # Encode candid args and compute SHA-256 checksum of the raw bytes

--- a/scripts/args/token_storage_init_args.template
+++ b/scripts/args/token_storage_init_args.template
@@ -1,0 +1,10 @@
+(variant { Init = record {
+  log_settings=opt record {
+    enable_console=opt true;
+    in_memory_records=opt 10000;
+    log_filter=opt "__LOG_FILTER__";
+  };
+  owner=principal "__OWNER__";
+  ckbtc_minter_id= principal "__CKBTC_MINTER_ID__";
+__TOKENS__
+}})

--- a/scripts/args/token_storage_tokens.template
+++ b/scripts/args/token_storage_tokens.template
@@ -1,11 +1,3 @@
-(record {
-  log_settings=opt record {
-    enable_console=opt true;
-    in_memory_records=opt 10000;
-    log_filter=opt "__LOG_FILTER__";
-  };
-  owner=principal "__OWNER__";
-  ckbtc_minter_id= principal "__CKBTC_MINTER_ID__";
   tokens = opt vec {
     record {
       details = variant { IC = record {
@@ -3248,4 +3240,3 @@
       enabled_by_default = false;
     };
   };
-})

--- a/scripts/args/token_storage_upgrade_args.template
+++ b/scripts/args/token_storage_upgrade_args.template
@@ -1,0 +1,4 @@
+(variant { Upgrade = record {
+  ckbtc_minter_id= principal "__CKBTC_MINTER_ID__";
+__TOKENS__
+}})

--- a/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.d.ts
+++ b/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.d.ts
@@ -167,11 +167,17 @@ export interface TokenRegistryMetadata {
   'last_updated' : bigint,
   'version' : bigint,
 }
+export type TokenStorageArgs = { 'Upgrade' : TokenStorageUpgradeData } |
+  { 'Init' : TokenStorageInitData };
 export interface TokenStorageInitData {
   'owner' : Principal,
   'tokens' : [] | [Array<RegistryToken>],
   'ckbtc_minter_id' : Principal,
   'log_settings' : [] | [LogServiceSettings],
+}
+export interface TokenStorageUpgradeData {
+  'tokens' : [] | [Array<RegistryToken>],
+  'ckbtc_minter_id' : Principal,
 }
 export interface UpdateBridgeTransactionInputArg {
   'retry_times' : [] | [number],

--- a/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.js
+++ b/src/cashier_frontend_new/src/lib/generated/token_storage/token_storage.did.js
@@ -20,6 +20,10 @@ export const idlFactory = ({ IDL }) => {
     'details' : ChainTokenDetails,
     'symbol' : IDL.Text,
   });
+  const TokenStorageUpgradeData = IDL.Record({
+    'tokens' : IDL.Opt(IDL.Vec(RegistryToken)),
+    'ckbtc_minter_id' : IDL.Principal,
+  });
   const LogServiceSettings = IDL.Record({
     'log_filter' : IDL.Opt(IDL.Text),
     'in_memory_records' : IDL.Opt(IDL.Nat64),
@@ -31,6 +35,10 @@ export const idlFactory = ({ IDL }) => {
     'tokens' : IDL.Opt(IDL.Vec(RegistryToken)),
     'ckbtc_minter_id' : IDL.Principal,
     'log_settings' : IDL.Opt(LogServiceSettings),
+  });
+  const TokenStorageArgs = IDL.Variant({
+    'Upgrade' : TokenStorageUpgradeData,
+    'Init' : TokenStorageInitData,
   });
   const TokenRegistryMetadata = IDL.Record({
     'last_updated' : IDL.Nat64,
@@ -350,6 +358,10 @@ export const init = ({ IDL }) => {
     'details' : ChainTokenDetails,
     'symbol' : IDL.Text,
   });
+  const TokenStorageUpgradeData = IDL.Record({
+    'tokens' : IDL.Opt(IDL.Vec(RegistryToken)),
+    'ckbtc_minter_id' : IDL.Principal,
+  });
   const LogServiceSettings = IDL.Record({
     'log_filter' : IDL.Opt(IDL.Text),
     'in_memory_records' : IDL.Opt(IDL.Nat64),
@@ -362,5 +374,9 @@ export const init = ({ IDL }) => {
     'ckbtc_minter_id' : IDL.Principal,
     'log_settings' : IDL.Opt(LogServiceSettings),
   });
-  return [TokenStorageInitData];
+  const TokenStorageArgs = IDL.Variant({
+    'Upgrade' : TokenStorageUpgradeData,
+    'Init' : TokenStorageInitData,
+  });
+  return [TokenStorageArgs];
 };

--- a/src/integration_tests/tests/token_storage/init_and_upgrade.rs
+++ b/src/integration_tests/tests/token_storage/init_and_upgrade.rs
@@ -3,7 +3,7 @@
 
 use candid::{Nat, Principal};
 use token_storage_types::{
-    init::TokenStorageUpgradeData,
+    init::{TokenStorageArgs, TokenStorageUpgradeData},
     token::{ChainTokenDetails, IcrcStandard, RegistryToken},
 };
 
@@ -88,10 +88,10 @@ async fn should_upgrade_with_tokens_upsert() {
             ctx.token_storage_principal,
             None,
             get_token_storage_canister_bytecode(),
-            (TokenStorageUpgradeData {
+            (TokenStorageArgs::Upgrade(TokenStorageUpgradeData {
                 ckbtc_minter_id: ckbtc_minter_principal,
                 tokens: Some(vec![new_token]),
-            },),
+            }),),
         )
         .await;
 
@@ -123,10 +123,10 @@ async fn should_upgrade_without_tokens_preserve_registry() {
             ctx.token_storage_principal,
             None,
             get_token_storage_canister_bytecode(),
-            (TokenStorageUpgradeData {
+            (TokenStorageArgs::Upgrade(TokenStorageUpgradeData {
                 ckbtc_minter_id: ckbtc_minter_principal,
                 tokens: None,
-            },),
+            }),),
         )
         .await;
 
@@ -174,10 +174,10 @@ async fn should_upgrade_upsert_existing_token() {
             ctx.token_storage_principal,
             None,
             get_token_storage_canister_bytecode(),
-            (TokenStorageUpgradeData {
+            (TokenStorageArgs::Upgrade(TokenStorageUpgradeData {
                 ckbtc_minter_id: ckbtc_minter_principal,
                 tokens: Some(vec![updated_icp]),
-            },),
+            }),),
         )
         .await;
 

--- a/src/integration_tests/tests/utils/mod.rs
+++ b/src/integration_tests/tests/utils/mod.rs
@@ -30,7 +30,7 @@ use std::{
 };
 use token_storage_client::client::TokenStorageClient;
 use token_storage_types::{
-    init::TokenStorageInitData,
+    init::{TokenStorageArgs, TokenStorageInitData},
     token::{ChainTokenDetails, IcrcStandard, RegistryToken},
 };
 
@@ -144,7 +144,7 @@ async fn deploy_template_state(template_dir: &Path) -> SharedPrincipals {
         &client,
         None,
         get_token_storage_canister_bytecode(),
-        &(TokenStorageInitData {
+        &(TokenStorageArgs::Init(TokenStorageInitData {
             log_settings: Some(log.clone()),
             owner: TestUser::TokenStorageAdmin.get_principal(),
             tokens: Some(vec![
@@ -218,7 +218,7 @@ async fn deploy_template_state(template_dir: &Path) -> SharedPrincipals {
                 },
             ]),
             ckbtc_minter_id: ckbtc_minter_principal,
-        }),
+        })),
     )
     .await;
 

--- a/src/token_storage/src/api/init_and_upgrade.rs
+++ b/src/token_storage/src/api/init_and_upgrade.rs
@@ -4,12 +4,16 @@
 use cashier_common::random::init_ic_rand;
 use ic_cdk::{init, post_upgrade, pre_upgrade};
 use log::{debug, error, info};
-use token_storage_types::init::{TokenStorageInitData, TokenStorageUpgradeData};
+use token_storage_types::init::TokenStorageArgs;
 
 use crate::{api::state::get_state, services::auth::Permission};
 
 #[init]
-fn init(init_data: TokenStorageInitData) {
+fn init(args: TokenStorageArgs) {
+    let init_data = match args {
+        TokenStorageArgs::Init(data) => data,
+        _ => ic_cdk::trap("Expected Init variant for canister init"),
+    };
     let log_config = init_data.log_settings.unwrap_or_default();
     let mut state = get_state();
 
@@ -52,7 +56,11 @@ fn init(init_data: TokenStorageInitData) {
 fn pre_upgrade() {}
 
 #[post_upgrade]
-fn post_upgrade(upgrade_data: TokenStorageUpgradeData) {
+fn post_upgrade(args: TokenStorageArgs) {
+    let upgrade_data = match args {
+        TokenStorageArgs::Upgrade(data) => data,
+        _ => ic_cdk::trap("Expected Upgrade variant for canister upgrade"),
+    };
     let mut state = get_state();
 
     if let Err(err) = state.log_service.init(None) {

--- a/src/token_storage_types/src/init.rs
+++ b/src/token_storage_types/src/init.rs
@@ -4,6 +4,13 @@ use serde::Deserialize;
 
 use crate::token::RegistryToken;
 
+/// Canister argument enum for both init and upgrade
+#[derive(Debug, Clone, CandidType, Deserialize)]
+pub enum TokenStorageArgs {
+    Init(TokenStorageInitData),
+    Upgrade(TokenStorageUpgradeData),
+}
+
 /// These are the arguments which are taken by the token_storage canister init fn
 #[derive(Debug, Clone, CandidType, Deserialize)]
 pub struct TokenStorageInitData {


### PR DESCRIPTION
**Root cause**

The .did file generated by candid-extractor only declared:

service : (TokenStorageInitData) -> { ... }
There was no TokenStorageUpgradeData in the .did. So when didc encode encoded the upgrade args, it encoded them as TokenStorageInitData type. The canister's post_upgrade expected TokenStorageUpgradeData — the Candid type table mismatch caused the TRAP:


[TRAP]: Fail to decode argument 0 from table0 to record { tokens : opt vec record { ... } }
<img width="917" height="215" alt="Screenshot 2026-03-27 at 13 18 22" src="https://github.com/user-attachments/assets/cdbcef8e-a397-41e0-a5df-a24a620615fa" />

**Fix**

Introduced TokenStorageArgs enum so both init and upgrade types are in the .did:
```
type TokenStorageArgs = variant { Init : TokenStorageInitData; Upgrade : TokenStorageUpgradeData };
service : (TokenStorageArgs) -> { ... }

```
Templates now wrap args in variant { Init = ... } or variant { Upgrade = ... } based on deploy mode.