### PR TITLE
[Ticket #869c0zv2u] Fix mempool rate limit issue

### DIFF
--- a/src/cashier_frontend_new/src/modules/bitcoin/services/mempoolService.ts
+++ b/src/cashier_frontend_new/src/modules/bitcoin/services/mempoolService.ts
@@ -92,6 +92,32 @@ class MempoolService {
   }
 
   /**
+   * Get transactions for a Bitcoin address.
+   * @param address Bitcoin address
+   * @returns Bitcoin transactions associated with the address or error message
+   */
+  async getAddressTransactions(
+    address: string,
+  ): Promise<Result<BitcoinTransaction[], string>> {
+    try {
+      const response = await this.#fetchWithFallback(`/address/${address}/txs`);
+      const data: MempoolTransaction[] = await response.json();
+      return Ok(
+        data.map((tx) =>
+          BitcoinTransactionMapper.fromMempoolApiResponse(
+            tx,
+            currentSecondTimestamp(),
+          ),
+        ),
+      );
+    } catch (error) {
+      return Err(
+        `Error fetching address transactions for ${address}: ${(error as Error).message}`,
+      );
+    }
+  }
+
+  /**
    * Get the current tip height of the Bitcoin blockchain.
    * @returns tip height or error message
    */

--- a/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.spec.ts
+++ b/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.spec.ts
@@ -1,4 +1,7 @@
-import type { BitcoinBlock } from "$modules/bitcoin/types/bitcoin_transaction";
+import type {
+  BitcoinBlock,
+  BitcoinTransaction,
+} from "$modules/bitcoin/types/bitcoin_transaction";
 import {
   BridgeTransactionStatus,
   BridgeType,
@@ -87,15 +90,17 @@ function fixture_of_minter_info(
 }
 
 function fixture_of_bitcoin_transaction(
-  overrides: Record<string, unknown> = {},
-) {
+  overrides: Partial<BitcoinTransaction> = {},
+): BitcoinTransaction {
   return {
     txid: "abc123",
     sender: "tb1qsender",
     is_confirmed: true,
     block_id: 840_000n,
     block_timestamp: 1_704_000_000n,
-    vout: [{ address: "tb1qreceiver", value: 50_000n }],
+    created_at_ts: 1_704_000_000,
+    vin: [],
+    vout: [{ address: "tb1qreceiver", value_satoshis: 50_000 }],
     ...overrides,
   };
 }
@@ -348,7 +353,7 @@ describe("BridgeStore", () => {
         Ok([
           fixture_of_bitcoin_transaction({
             is_confirmed: false,
-            vout: [{ address: "tb1qother", value: 50_000n }],
+            vout: [{ address: "tb1qother", value_satoshis: 50_000 }],
           }),
         ]),
       );
@@ -416,6 +421,109 @@ describe("BridgeStore", () => {
 
       // Assert
       expect(result).toBe(true);
+    });
+  });
+
+  describe("processMempoolTransactions", () => {
+    it("it_should_not_create_import_bridge_when_btc_address_is_missing", async () => {
+      // Arrange
+      const txs = [fixture_of_bitcoin_transaction({ is_confirmed: false })];
+
+      // Act
+      await bridgeStore.processMempoolTransactions(txs);
+
+      // Assert
+      expect(mockGetDepositFee).not.toHaveBeenCalled();
+      expect(mockCreateImportBridgeTransaction).not.toHaveBeenCalled();
+    });
+
+    it("it_should_skip_mempool_transactions_that_are_already_processed", async () => {
+      // Arrange
+      mockPersistedValues["btcAddress"] = "tb1qreceiver";
+      mockQueryInstances[0].data = [
+        { ...fixture_of_import_bridge(), total_amount_usd: 0 },
+      ];
+      const txs = [fixture_of_bitcoin_transaction({ is_confirmed: false })];
+
+      // Act
+      await bridgeStore.processMempoolTransactions(txs);
+
+      // Assert
+      expect(mockGetDepositFee).not.toHaveBeenCalled();
+      expect(mockCreateImportBridgeTransaction).not.toHaveBeenCalled();
+    });
+
+    it("it_should_create_import_bridge_and_refresh_queries_for_new_mempool_transaction", async () => {
+      // Arrange
+      mockPersistedValues["btcAddress"] = "tb1qreceiver";
+      const btcTx = fixture_of_bitcoin_transaction({ is_confirmed: false });
+      mockGetDepositFee.mockResolvedValue(1_000n);
+      mockCreateImportBridgeTransaction.mockResolvedValue(
+        Ok(fixture_of_import_bridge()),
+      );
+
+      // Act
+      await bridgeStore.processMempoolTransactions([btcTx]);
+
+      // Assert
+      expect(mockGetDepositFee).toHaveBeenCalledTimes(1);
+      expect(mockCreateImportBridgeTransaction).toHaveBeenCalledWith(
+        "tb1qsender",
+        "tb1qreceiver",
+        btcTx,
+        1_000n,
+        0n,
+        true,
+      );
+      expect(mockQueryInstances[0].refresh).toHaveBeenCalledTimes(1);
+      expect(mockQueryInstances[1].refresh).toHaveBeenCalledTimes(1);
+    });
+
+    it("it_should_continue_processing_next_transactions_when_one_creation_fails", async () => {
+      // Arrange
+      mockPersistedValues["btcAddress"] = "tb1qreceiver";
+      const firstTx = fixture_of_bitcoin_transaction({
+        txid: "txid-1",
+        sender: "tb1qsender1",
+        is_confirmed: false,
+      });
+      const secondTx = fixture_of_bitcoin_transaction({
+        txid: "txid-2",
+        sender: "tb1qsender2",
+        is_confirmed: false,
+      });
+      mockGetDepositFee.mockResolvedValue(1_000n);
+      mockCreateImportBridgeTransaction
+        .mockResolvedValueOnce(Err("create failed"))
+        .mockResolvedValueOnce(
+          Ok(fixture_of_import_bridge({ bridge_id: "import_txid-2" })),
+        );
+
+      // Act
+      await bridgeStore.processMempoolTransactions([firstTx, secondTx]);
+
+      // Assert
+      expect(mockGetDepositFee).toHaveBeenCalledTimes(2);
+      expect(mockCreateImportBridgeTransaction).toHaveBeenNthCalledWith(
+        1,
+        "tb1qsender1",
+        "tb1qreceiver",
+        firstTx,
+        1_000n,
+        0n,
+        true,
+      );
+      expect(mockCreateImportBridgeTransaction).toHaveBeenNthCalledWith(
+        2,
+        "tb1qsender2",
+        "tb1qreceiver",
+        secondTx,
+        1_000n,
+        0n,
+        true,
+      );
+      expect(mockQueryInstances[0].refresh).toHaveBeenCalledTimes(1);
+      expect(mockQueryInstances[1].refresh).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.spec.ts
+++ b/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.spec.ts
@@ -121,7 +121,7 @@ const {
   mockGetDepositFee,
   mockUpdateBalanceWithMintedInfo,
   mockRetrieveBtcStatusV2,
-  mockGetMempoolTxs,
+  mockGetAddressTransactions,
   mockGetTransactionById,
   mockGetTipHeight,
   mockGetLatestBlocksFromHeight,
@@ -145,7 +145,7 @@ const {
     mockGetDepositFee: vi.fn(),
     mockUpdateBalanceWithMintedInfo: vi.fn(),
     mockRetrieveBtcStatusV2: vi.fn(),
-    mockGetMempoolTxs: vi.fn(),
+    mockGetAddressTransactions: vi.fn(),
     mockGetTransactionById: vi.fn(),
     mockGetTipHeight: vi.fn(),
     mockGetLatestBlocksFromHeight: vi.fn(),
@@ -206,7 +206,7 @@ vi.mock("$modules/bitcoin/services/ckBTCMinterService", () => ({
 
 vi.mock("$modules/bitcoin/services/mempoolService", () => ({
   mempoolService: {
-    getMempoolTxs: mockGetMempoolTxs,
+    getAddressTransactions: mockGetAddressTransactions,
     getTransactionById: mockGetTransactionById,
     getTipHeight: mockGetTipHeight,
     getLatestBlocksFromHeight: mockGetLatestBlocksFromHeight,
@@ -331,7 +331,7 @@ describe("BridgeStore", () => {
   describe("lookupMempoolTransactionByAddress", () => {
     it("it_should_fail_lookup_mempool_transaction_due_to_mempool_error", async () => {
       // Arrange
-      mockGetMempoolTxs.mockResolvedValue(Err("Network error"));
+      mockGetAddressTransactions.mockResolvedValue(Err("Network error"));
 
       // Act
       const result =
@@ -339,18 +339,18 @@ describe("BridgeStore", () => {
 
       // Assert
       expect(result.isErr()).toBe(true);
-      expect(result.unwrapErr()).toContain("Get mempool tx IDs failed");
+      expect(result.unwrapErr()).toContain("Get address transactions failed");
     });
 
     it("it_should_return_empty_when_no_txs_match_address", async () => {
       // Arrange
-      mockGetMempoolTxs.mockResolvedValue(Ok(["txid1"]));
-      mockGetTransactionById.mockResolvedValue(
-        Ok(
+      mockGetAddressTransactions.mockResolvedValue(
+        Ok([
           fixture_of_bitcoin_transaction({
+            is_confirmed: false,
             vout: [{ address: "tb1qother", value: 50_000n }],
           }),
-        ),
+        ]),
       );
 
       // Act
@@ -364,9 +364,8 @@ describe("BridgeStore", () => {
 
     it("it_should_return_txs_matching_address", async () => {
       // Arrange
-      mockGetMempoolTxs.mockResolvedValue(Ok(["txid1"]));
-      mockGetTransactionById.mockResolvedValue(
-        Ok(fixture_of_bitcoin_transaction()),
+      mockGetAddressTransactions.mockResolvedValue(
+        Ok([fixture_of_bitcoin_transaction({ is_confirmed: false })]),
       );
 
       // Act
@@ -377,6 +376,21 @@ describe("BridgeStore", () => {
       expect(result.isOk()).toBe(true);
       expect(result.unwrap()).toHaveLength(1);
       expect(result.unwrap()[0].txid).toBe("abc123");
+    });
+
+    it("it_should_filter_out_confirmed_transactions", async () => {
+      // Arrange
+      mockGetAddressTransactions.mockResolvedValue(
+        Ok([fixture_of_bitcoin_transaction({ is_confirmed: true })]),
+      );
+
+      // Act
+      const result =
+        await bridgeStore.lookupMempoolTransactionByAddress("tb1qreceiver");
+
+      // Assert
+      expect(result.isOk()).toBe(true);
+      expect(result.unwrap()).toHaveLength(0);
     });
   });
 

--- a/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.ts
+++ b/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.ts
@@ -166,27 +166,6 @@ class BridgeStore {
       storageType: "sessionStorage",
     });
 
-    this.#mempoolTxQuery = managedState<BitcoinTransaction[]>({
-      queryFn: async () => {
-        if (!this.btcAddress) {
-          return [];
-        }
-        const mempoolTxsResult = await this.lookupMempoolTransactionByAddress(
-          this.btcAddress,
-        );
-
-        if (mempoolTxsResult.isErr()) {
-          return [];
-        }
-
-        const mempoolTxs = mempoolTxsResult.unwrap();
-        return mempoolTxs;
-      },
-      refetchInterval: 300 * 1000,
-      persistedKey: ["walletBridgeStore_mempoolTxs"],
-      storageType: "sessionStorage",
-    });
-
     $effect.root(() => {
       $effect(() => {
         if (authState.account == null) {
@@ -343,15 +322,57 @@ class BridgeStore {
   }
 
   /**
-   * Process mempool transactions into bridge transactions.
+   * Create a scheduled task to fetch and process mempool transactions
    * @returns
    */
-  async processMempoolTransactions() {
-    if (!this.mempoolTxs) {
-      return;
+  createMempoolTransactionTask(): NodeJS.Timeout {
+    return setInterval(async () => {
+      if (!this.btcAddress) {
+        return;
+      }
+      const result = await this.lookupMempoolTransactionByAddress(
+        this.btcAddress,
+      );
+      if (result.isErr()) {
+        return;
+      }
+      await this.processMempoolTransactions(result.unwrap());
+    }, MEMPOOL_API_POOLING_INTERVAL_SECONDS * 1000);
+  }
+
+  /**
+   * Fetch mempool transactions associated with the btc address using mempool API
+   * @param address
+   * @returns btc transactions or error message if failed to fetch
+   */
+  async lookupMempoolTransactionByAddress(
+    address: string,
+  ): Promise<Result<BitcoinTransaction[], string>> {
+    const addressTxsResult =
+      await mempoolService.getAddressTransactions(address);
+    if (addressTxsResult.isErr()) {
+      return Err(
+        `Get address transactions failed: ${addressTxsResult.unwrapErr()}`,
+      );
     }
 
-    this.mempoolTxs.forEach(async (btcTx: BitcoinTransaction) => {
+    return Ok(
+      addressTxsResult
+        .unwrap()
+        .filter(
+          (tx) =>
+            !tx.is_confirmed &&
+            tx.vout.some((output) => output.address === address),
+        ),
+    );
+  }
+
+  /**
+   * Process mempool transactions fetched from mempool API
+   * @param txs
+   */
+  async processMempoolTransactions(txs: BitcoinTransaction[]) {
+    txs.forEach(async (btcTx: BitcoinTransaction) => {
       if (this.isMempoolTxProcessed(btcTx.txid)) {
         return;
       }
@@ -360,19 +381,15 @@ class BridgeStore {
         return;
       }
 
-      const receiverBtcAddress = this.btcAddress;
       const depositFee = await ckBTCMinterService.getDepositFee();
-      const withdrawalFee = 0n;
-      const isImporting = true;
-
       const createBridgeResult =
         await tokenStorageService.createImportBridgeTransaction(
           btcTx.sender,
-          receiverBtcAddress,
+          this.btcAddress,
           btcTx,
           depositFee,
-          withdrawalFee,
-          isImporting,
+          0n,
+          true,
         );
 
       if (createBridgeResult.isErr()) {
@@ -385,36 +402,6 @@ class BridgeStore {
         this.#importBridgeTxQuery.refresh();
       }
     });
-  }
-
-  /**
-   * Look up mempool transactions by BTC address.
-   * @param address
-   * @returns array of BitcoinTransaction
-   */
-  async lookupMempoolTransactionByAddress(
-    address: string,
-  ): Promise<Result<BitcoinTransaction[], string>> {
-    const txIdsResult = await mempoolService.getMempoolTxs();
-    if (txIdsResult.isErr()) {
-      return Err(`Get mempool tx IDs failed: ${txIdsResult.unwrapErr()}`);
-    }
-
-    const txIds = txIdsResult.unwrap();
-    const transactionTasks = txIds.map(async (txid) => {
-      const txResult = await mempoolService.getTransactionById(txid);
-      if (txResult.isErr()) {
-        return null;
-      }
-      return txResult.unwrap();
-    });
-
-    const transactions = await Promise.all(transactionTasks);
-    const filteredTransactions = transactions.filter(
-      (tx): tx is BitcoinTransaction =>
-        tx !== null && tx.vout.some((output) => output.address === address),
-    );
-    return Ok(filteredTransactions);
   }
 
   /**

--- a/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.ts
+++ b/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.ts
@@ -172,6 +172,11 @@ class BridgeStore {
           this.reset();
         } else {
           // Clean up the previous interval if any
+          if (this.mempoolTxsTask) {
+            clearInterval(this.mempoolTxsTask);
+            this.mempoolTxsTask = null;
+          }
+
           if (this.processPendingTxsTask) {
             clearInterval(this.processPendingTxsTask);
             this.processPendingTxsTask = null;

--- a/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.ts
+++ b/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.ts
@@ -366,13 +366,13 @@ class BridgeStore {
    * @param txs
    */
   async processMempoolTransactions(txs: BitcoinTransaction[]) {
-    txs.forEach(async (btcTx: BitcoinTransaction) => {
-      if (this.isMempoolTxProcessed(btcTx.txid)) {
-        return;
-      }
+    if (!this.btcAddress) {
+      return;
+    }
 
-      if (!this.btcAddress) {
-        return;
+    for (const btcTx of txs) {
+      if (this.isMempoolTxProcessed(btcTx.txid)) {
+        continue;
       }
 
       const depositFee = await ckBTCMinterService.getDepositFee();
@@ -395,7 +395,7 @@ class BridgeStore {
         this.#bridgeTxQuery.refresh();
         this.#importBridgeTxQuery.refresh();
       }
-    });
+    }
   }
 
   /**

--- a/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.ts
+++ b/src/cashier_frontend_new/src/modules/bitcoin/state/bridgeStore.svelte.ts
@@ -40,7 +40,6 @@ class BridgeStore {
     "ckbtcMinterMinConfirmations",
     null,
   );
-  #mempoolTxQuery;
   #bridgeTxQuery;
   #allBridges: BridgeTransactionWithUsdValue[] = [];
   #currentPage = 0;
@@ -56,6 +55,7 @@ class BridgeStore {
   #exportCurrentPage = 0;
   hasMoreExports = $state<boolean>(true);
 
+  mempoolTxsTask: NodeJS.Timeout | null = null;
   processPendingTxsTask: NodeJS.Timeout | null = null;
   isRefreshing = $state<boolean>(false);
 
@@ -189,14 +189,9 @@ class BridgeStore {
           this.#bridgeTxQuery.refresh();
           this.#importBridgeTxQuery.refresh();
           this.#exportBridgeTxQuery.refresh();
+          this.mempoolTxsTask = this.createMempoolTransactionTask();
           this.processPendingTxsTask =
             this.createPendingBridgeTransactionsTask();
-        }
-      });
-
-      $effect(() => {
-        if (authState.account && this.#mempoolTxQuery.data) {
-          this.processMempoolTransactions();
         }
       });
     });
@@ -208,10 +203,6 @@ class BridgeStore {
 
   get minConfirmations() {
     return this.#minConfirmations.current ?? 0;
-  }
-
-  get mempoolTxs() {
-    return this.#mempoolTxQuery.data;
   }
 
   get bridgeTxs() {
@@ -280,9 +271,12 @@ class BridgeStore {
     this.hasMoreExports = true;
     this.#exportBridgeTxQuery.reset();
 
-    this.#mempoolTxQuery.reset();
-
     // Clear interval on reset
+    if (this.mempoolTxsTask) {
+      clearInterval(this.mempoolTxsTask);
+      this.mempoolTxsTask = null;
+    }
+
     if (this.processPendingTxsTask) {
       clearInterval(this.processPendingTxsTask);
       this.processPendingTxsTask = null;


### PR DESCRIPTION
This PR includes fix for the [issue](https://app.clickup.com/t/869c0zv2u).

The root cause:
- current implementation fetches full mempool txs list, then filter tx by btc address to find the importing tx. On mainnet, the mempool is very crowded with thousand ongoing txs,leading to FE making too much api calls

Fixes:
- lookup only txs associated with btc address, not full mempool
making mempool query as scheduled task, run periodically after user logging in.