### PR TITLE
[Ticket #869ctkktp] Fee is more than real execution

### DIFF
--- a/src/cashier_frontend_new/src/modules/creationLink/components/drawers/FeeInfoDrawer.svelte
+++ b/src/cashier_frontend_new/src/modules/creationLink/components/drawers/FeeInfoDrawer.svelte
@@ -66,7 +66,9 @@
 
   // Separate network fees and link creation fee
   const networkFees = $derived.by(() => {
-    return feesBreakdown.filter((fee) => fee.name === "Network fees");
+    return feesBreakdown.filter(
+      (fee) => fee.name === "Network fees" || fee.name === "Network fee",
+    );
   });
 
   const linkCreationFee = $derived.by(() => {
@@ -159,7 +161,7 @@
       {/if}
 
       {#each feesBreakdown as fee (fee.name + "_" + fee.tokenAddress)}
-        {#if fee.name !== "Network fees" && fee.name !== "Link creation fee"}
+        {#if fee.name !== "Network fees" && fee.name !== "Network fee" && fee.name !== "Link creation fee"}
           {@const feeView = formatFeeBreakdownItem(fee)}
           <div>
             <div class="flex justify-between items-center">

--- a/src/cashier_frontend_new/src/modules/creationLink/components/drawers/FeeInfoDrawer.svelte.spec.ts
+++ b/src/cashier_frontend_new/src/modules/creationLink/components/drawers/FeeInfoDrawer.svelte.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
-import { render, screen } from "@testing-library/svelte";
-import { describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import FeeInfoDrawer from "./FeeInfoDrawer.svelte";
 
 vi.mock("$lib/i18n", () => ({
@@ -29,6 +29,16 @@ function fixture_of_fees_breakdown() {
     },
   ];
 }
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  cleanup(); // destroy component → queues fake timer
+  vi.runAllTimers(); // drain fake timer while jsdom is alive
+  vi.useRealTimers(); // restore for next test
+});
 
 describe("FeeInfoDrawer", () => {
   it("it_should_do_render_fee_breakdown_rows_when_open", () => {

--- a/src/cashier_frontend_new/src/modules/shared/services/feeService.spec.ts
+++ b/src/cashier_frontend_new/src/modules/shared/services/feeService.spec.ts
@@ -495,6 +495,67 @@ describe("FeeService", () => {
         expect(result[0].fee?.feeType).toBe(FeeType.NETWORK_FEE);
       });
 
+      it("subtracts one ledger fee from CREATE_LINK_FEE when fee token is also an outgoing funding asset", () => {
+        // Make fee token address match the token used in this action.
+        vi.spyOn(svc, "getLinkCreationFee").mockReturnValue({
+          amount: 10_000n,
+          tokenAddress,
+          symbol: "ICP",
+          decimals: 8,
+        });
+
+        const treasuryOnly = createMockAction(ActionType.CREATE_LINK, [
+          createIntentWithPayload(
+            "treasury-only",
+            IntentTask.TRANSFER_WALLET_TO_TREASURY,
+            100_000_000n,
+          ),
+        ]);
+
+        const withFundingAsset = createMockAction(ActionType.CREATE_LINK, [
+          createIntentWithPayload(
+            "funding-asset",
+            IntentTask.TRANSFER_WALLET_TO_LINK,
+            100_000_000n,
+          ),
+          createIntentWithPayload(
+            "treasury",
+            IntentTask.TRANSFER_WALLET_TO_TREASURY,
+            100_000_000n,
+          ),
+        ]);
+
+        const resA = svc.buildFromAction(
+          treasuryOnly,
+          1,
+          tokensMap,
+          from.getPrincipal().toText(),
+        );
+        const resB = svc.buildFromAction(
+          withFundingAsset,
+          1,
+          tokensMap,
+          from.getPrincipal().toText(),
+        );
+
+        const createLinkFeeA = resA.find(
+          (p) => p.fee?.feeType === FeeType.CREATE_LINK_FEE,
+        );
+        const createLinkFeeB = resB.find(
+          (p) => p.fee?.feeType === FeeType.CREATE_LINK_FEE,
+        );
+
+        expect(createLinkFeeA).toBeDefined();
+        expect(createLinkFeeB).toBeDefined();
+
+        if (!createLinkFeeA || !createLinkFeeB) return;
+
+        // When fee token is also funded as an outgoing asset, displayed total should be reduced by one ledger fee.
+        expect(createLinkFeeB.asset.amount).toBe(
+          createLinkFeeA.asset.amount - LEDGER_FEE,
+        );
+      });
+
       it("calculates USD values when priceUSD available", () => {
         const intent = createIntentWithPayload(
           "id-5",
@@ -783,5 +844,128 @@ describe("FeeService", () => {
         expect(result).toHaveLength(0);
       });
     });
+  });
+});
+
+describe("FeeService - mocked $shared edge cases", () => {
+  it("clamps CREATE_LINK_FEE asset amount to 0 when overlap subtraction would go negative", async () => {
+    vi.resetModules();
+    const tokenAddress = assets[0].address.toString();
+
+    // Local mock: make calculateIntentFees return a total equal to exactly one ledger fee.
+    vi.doMock("$shared", async () => {
+      const actual = await vi.importActual<typeof import("$shared")>("$shared");
+      return {
+        ...actual,
+        calculateIntentFees: vi.fn(() => ({
+          intent_total_amount: "0",
+          intent_total_network_fee: LEDGER_FEE.toString(),
+          intent_user_fee: "0",
+        })),
+      };
+    });
+
+    const { FeeService: FeeServiceWithMock } = await import("./feeService");
+    const localSvc = new FeeServiceWithMock();
+
+    vi.spyOn(localSvc, "getLinkCreationFee").mockReturnValue({
+      amount: 0n,
+      tokenAddress,
+      symbol: "ICP",
+      decimals: 8,
+    });
+
+    const token = createMockToken(tokenAddress, {
+      symbol: "ICP",
+      decimals: 8,
+      fee: LEDGER_FEE,
+      priceUSD: undefined,
+    });
+    const tokensMap = { [tokenAddress]: token };
+
+    const action = createMockAction(ActionType.CREATE_LINK, [
+      createIntentWithPayload(
+        "funding-asset",
+        IntentTask.TRANSFER_WALLET_TO_LINK,
+        1n,
+      ),
+      createIntentWithPayload(
+        "treasury",
+        IntentTask.TRANSFER_WALLET_TO_TREASURY,
+        1n,
+      ),
+    ]);
+
+    const res = localSvc.buildFromAction(
+      action,
+      1,
+      tokensMap,
+      from.getPrincipal().toText(),
+    );
+    const createLinkFee = res.find(
+      (p) => p.fee?.feeType === FeeType.CREATE_LINK_FEE,
+    );
+    expect(createLinkFee).toBeDefined();
+    expect(createLinkFee?.asset.amount).toBe(0n);
+  });
+
+  it("forecastLinkCreationFees uses intent_total_amount + intent_total_network_fee for asset amount and USD", async () => {
+    vi.resetModules();
+
+    const totalAmount = 1_000_000n;
+    const totalNetworkFee = 250_000n;
+
+    vi.doMock("$shared", async () => {
+      const actual = await vi.importActual<typeof import("$shared")>("$shared");
+      return {
+        ...actual,
+        calculateIntentFees: vi.fn(() => ({
+          intent_total_amount: totalAmount.toString(),
+          intent_total_network_fee: totalNetworkFee.toString(),
+          intent_user_fee: "0",
+        })),
+      };
+    });
+
+    const { FeeService: FeeServiceWithMock } = await import("./feeService");
+    const localSvc = new FeeServiceWithMock();
+
+    const token = createMockToken("mock-token", {
+      symbol: "MOCK",
+      decimals: 8,
+      fee: LEDGER_FEE,
+      priceUSD: 2.0,
+    });
+
+    // Also provide the link-fee token required by forecastLinkCreationFees.
+    const linkFeeInfo = localSvc.getLinkCreationFee();
+    const linkFeeToken = createMockToken(linkFeeInfo.tokenAddress, {
+      symbol: "ICP",
+      decimals: 8,
+      fee: LEDGER_FEE,
+      priceUSD: 1.0,
+    });
+
+    const tokensMap = {
+      [token.address]: token,
+      [linkFeeToken.address]: linkFeeToken,
+    } as Record<string, TokenWithPriceAndBalance>;
+
+    const res = localSvc.forecastLinkCreationFees(
+      [{ address: token.address, useAmount: 123n }],
+      3,
+      tokensMap,
+    );
+
+    expect(res.isOk()).toBe(true);
+    const pairs = res.unwrap();
+    const assetPair = pairs.find((p) => p.asset.address === token.address);
+    expect(assetPair).toBeDefined();
+    if (!assetPair) return;
+
+    const expectedRaw = totalAmount + totalNetworkFee;
+    const expectedUi = parseBalanceUnits(expectedRaw, token.decimals);
+    expect(assetPair.asset.amount).toBe(formatNumber(expectedUi));
+    expect(assetPair.asset.usdValueStr).toBeDefined();
   });
 });

--- a/src/cashier_frontend_new/src/modules/shared/services/feeService.spec.ts
+++ b/src/cashier_frontend_new/src/modules/shared/services/feeService.spec.ts
@@ -519,13 +519,40 @@ describe("FeeService", () => {
           decimals: 8,
         });
 
-        const treasuryOnly = createMockAction(ActionType.CREATE_LINK, [
-          createIntentWithPayload(
-            "treasury-only",
-            IntentTask.TRANSFER_WALLET_TO_TREASURY,
-            100_000_000n,
-          ),
-        ]);
+        // A "complete" CREATE_LINK action must include both:
+        // - funding intent (TRANSFER_WALLET_TO_LINK)
+        // - fee intent (TRANSFER_WALLET_TO_TREASURY)
+        //
+        // Baseline: fund the link with a different token so there's no overlap.
+        const otherPrincipal = Principal.anonymous();
+        const otherTokenAddress = otherPrincipal.toText();
+        const otherAsset = new Asset(otherPrincipal);
+        const tokensMapWithOther = {
+          ...tokensMap,
+          [otherTokenAddress]: createMockToken(otherTokenAddress, {
+            symbol: "OTHER",
+            decimals: 8,
+            fee: LEDGER_FEE,
+            priceUSD: undefined,
+          }),
+        };
+
+        const withDifferentFundingAsset = createMockAction(
+          ActionType.CREATE_LINK,
+          [
+            createIntentWithPayloadAndAsset(
+              "funding-asset",
+              IntentTask.TRANSFER_WALLET_TO_LINK,
+              100_000_000n,
+              otherAsset,
+            ),
+            createIntentWithPayload(
+              "treasury",
+              IntentTask.TRANSFER_WALLET_TO_TREASURY,
+              100_000_000n,
+            ),
+          ],
+        );
 
         const withFundingAsset = createMockAction(ActionType.CREATE_LINK, [
           createIntentWithPayload(
@@ -541,9 +568,9 @@ describe("FeeService", () => {
         ]);
 
         const resA = svc.buildFromAction(
-          treasuryOnly,
+          withDifferentFundingAsset,
           1,
-          tokensMap,
+          tokensMapWithOther,
           from.getPrincipal().toText(),
         );
         const resB = svc.buildFromAction(
@@ -565,7 +592,7 @@ describe("FeeService", () => {
 
         if (!createLinkFeeA || !createLinkFeeB) return;
 
-        // When fee token is also funded as an outgoing asset, displayed total should be reduced by one ledger fee.
+        // When the deposited token equals the fee token, displayed total should be reduced by one ledger fee.
         expect(createLinkFeeB.asset.amount).toBe(
           createLinkFeeA.asset.amount - LEDGER_FEE,
         );
@@ -580,8 +607,9 @@ describe("FeeService", () => {
           decimals: 8,
         });
 
-        const otherTokenAddress = Principal.anonymous().toText();
-        const otherAsset = new Asset(Principal.anonymous());
+        const otherPrincipal = Principal.anonymous();
+        const otherTokenAddress = otherPrincipal.toText();
+        const otherAsset = new Asset(otherPrincipal);
         const tokensMapWithOther = {
           ...tokensMap,
           [otherTokenAddress]: createMockToken(otherTokenAddress, {
@@ -592,13 +620,23 @@ describe("FeeService", () => {
           }),
         };
 
-        const treasuryOnly = createMockAction(ActionType.CREATE_LINK, [
-          createIntentWithPayload(
-            "treasury-only",
-            IntentTask.TRANSFER_WALLET_TO_TREASURY,
-            100_000_000n,
-          ),
-        ]);
+        // "Complete" action but with different funding token so there's no overlap.
+        const withDifferentFundingAssetZeroAmount = createMockAction(
+          ActionType.CREATE_LINK,
+          [
+            createIntentWithPayloadAndAsset(
+              "funding-asset",
+              IntentTask.TRANSFER_WALLET_TO_LINK,
+              0n,
+              otherAsset,
+            ),
+            createIntentWithPayload(
+              "treasury",
+              IntentTask.TRANSFER_WALLET_TO_TREASURY,
+              100_000_000n,
+            ),
+          ],
+        );
 
         const withDifferentFundingAsset = createMockAction(
           ActionType.CREATE_LINK,
@@ -618,7 +656,7 @@ describe("FeeService", () => {
         );
 
         const resA = svc.buildFromAction(
-          treasuryOnly,
+          withDifferentFundingAssetZeroAmount,
           1,
           tokensMapWithOther,
           from.getPrincipal().toText(),

--- a/src/cashier_frontend_new/src/modules/shared/services/feeService.spec.ts
+++ b/src/cashier_frontend_new/src/modules/shared/services/feeService.spec.ts
@@ -47,6 +47,21 @@ const createIntentWithPayload = (
   return new Intent(id, task, new IntentType(payload), 0n, IntentState.CREATED);
 };
 
+const createIntentWithPayloadAndAsset = (
+  id: string,
+  task: IntentTask,
+  amount: bigint,
+  asset: Asset,
+): Intent => {
+  const payload: IntentPayload = new TransferData(
+    toWallet,
+    asset,
+    fromWallet,
+    amount,
+  );
+  return new Intent(id, task, new IntentType(payload), 0n, IntentState.CREATED);
+};
+
 const LEDGER_FEE = 10_000n; // 0.0001 token in e8s
 
 // Helper: Create mock token
@@ -495,7 +510,7 @@ describe("FeeService", () => {
         expect(result[0].fee?.feeType).toBe(FeeType.NETWORK_FEE);
       });
 
-      it("subtracts one ledger fee from CREATE_LINK_FEE when fee token is also an outgoing funding asset", () => {
+      it("subtracts one ledger fee from CREATE_LINK_FEE when deposited token equals link-creation-fee token", () => {
         // Make fee token address match the token used in this action.
         vi.spyOn(svc, "getLinkCreationFee").mockReturnValue({
           amount: 10_000n,
@@ -554,6 +569,80 @@ describe("FeeService", () => {
         expect(createLinkFeeB.asset.amount).toBe(
           createLinkFeeA.asset.amount - LEDGER_FEE,
         );
+      });
+
+      it("does not subtract ledger fee when deposited token differs from link-creation-fee token", () => {
+        // Fee token is ICP (tokenAddress). We'll deposit a different token to the link.
+        vi.spyOn(svc, "getLinkCreationFee").mockReturnValue({
+          amount: 10_000n,
+          tokenAddress,
+          symbol: "ICP",
+          decimals: 8,
+        });
+
+        const otherTokenAddress = Principal.anonymous().toText();
+        const otherAsset = new Asset(Principal.anonymous());
+        const tokensMapWithOther = {
+          ...tokensMap,
+          [otherTokenAddress]: createMockToken(otherTokenAddress, {
+            symbol: "OTHER",
+            decimals: 8,
+            fee: LEDGER_FEE,
+            priceUSD: undefined,
+          }),
+        };
+
+        const treasuryOnly = createMockAction(ActionType.CREATE_LINK, [
+          createIntentWithPayload(
+            "treasury-only",
+            IntentTask.TRANSFER_WALLET_TO_TREASURY,
+            100_000_000n,
+          ),
+        ]);
+
+        const withDifferentFundingAsset = createMockAction(
+          ActionType.CREATE_LINK,
+          [
+            createIntentWithPayloadAndAsset(
+              "funding-asset",
+              IntentTask.TRANSFER_WALLET_TO_LINK,
+              100_000_000n,
+              otherAsset,
+            ),
+            createIntentWithPayload(
+              "treasury",
+              IntentTask.TRANSFER_WALLET_TO_TREASURY,
+              100_000_000n,
+            ),
+          ],
+        );
+
+        const resA = svc.buildFromAction(
+          treasuryOnly,
+          1,
+          tokensMapWithOther,
+          from.getPrincipal().toText(),
+        );
+        const resB = svc.buildFromAction(
+          withDifferentFundingAsset,
+          1,
+          tokensMapWithOther,
+          from.getPrincipal().toText(),
+        );
+
+        const createLinkFeeA = resA.find(
+          (p) => p.fee?.feeType === FeeType.CREATE_LINK_FEE,
+        );
+        const createLinkFeeB = resB.find(
+          (p) => p.fee?.feeType === FeeType.CREATE_LINK_FEE,
+        );
+
+        expect(createLinkFeeA).toBeDefined();
+        expect(createLinkFeeB).toBeDefined();
+        if (!createLinkFeeA || !createLinkFeeB) return;
+
+        // Since the deposited token differs, no network-fee overlap should be subtracted.
+        expect(createLinkFeeB.asset.amount).toBe(createLinkFeeA.asset.amount);
       });
 
       it("calculates USD values when priceUSD available", () => {

--- a/src/cashier_frontend_new/src/modules/shared/services/feeService.ts
+++ b/src/cashier_frontend_new/src/modules/shared/services/feeService.ts
@@ -145,10 +145,11 @@ export class FeeService {
   ): AssetAndFeeList {
     const pairs: AssetAndFee[] = [];
     const feeConfig = this.getLinkCreationFee();
-    const feeTokenAddress = feeConfig.tokenAddress.toLowerCase();
+    const feeTokenAddress = feeConfig.tokenAddress?.toLowerCase() ?? "";
 
     const hasFeeTokenOutgoingAssetIntent =
       action.type === ActionType.CREATE_LINK &&
+      feeTokenAddress !== "" &&
       action.intents.some((intent) => {
         const address = intent.type.payload.asset.address.toString();
         return (
@@ -344,8 +345,8 @@ export class FeeService {
 
       const isCreateLinkFee = item.fee.feeType === FeeType.CREATE_LINK_FEE;
 
-      let amount = isCreateLinkFee ? item.asset.amount : item.fee.amount;
-      let usdAmount = isCreateLinkFee
+      const amount = isCreateLinkFee ? item.asset.amount : item.fee.amount;
+      const usdAmount = isCreateLinkFee
         ? parseFloat(item.asset.usdValueStr ?? "0")
         : item.fee.usdValue;
 
@@ -460,9 +461,12 @@ export class FeeService {
       return Err(new Error("Link fee token not found"));
     }
 
-    const isFeeTokenAlsoAsset = linkAssets.some(
-      (a) => a.address.toLowerCase() === linkFeeInfo.tokenAddress.toLowerCase(),
-    );
+    const isFeeTokenAlsoAsset =
+      linkFeeInfo.tokenAddress !== undefined &&
+      linkAssets.some(
+        (a) =>
+          a.address.toLowerCase() === linkFeeInfo.tokenAddress!.toLowerCase(),
+      );
 
     const intentFees = calculateIntentFees({
       intent_participants: IntentParticipants.CreatorToTreasury,

--- a/src/cashier_frontend_new/src/modules/shared/services/feeService.ts
+++ b/src/cashier_frontend_new/src/modules/shared/services/feeService.ts
@@ -145,6 +145,17 @@ export class FeeService {
   ): AssetAndFeeList {
     const pairs: AssetAndFee[] = [];
     const feeConfig = this.getLinkCreationFee();
+    const feeTokenAddress = feeConfig.tokenAddress.toLowerCase();
+
+    const hasFeeTokenOutgoingAssetIntent =
+      action.type === ActionType.CREATE_LINK &&
+      action.intents.some((intent) => {
+        const address = intent.type.payload.asset.address.toString();
+        return (
+          address.toLowerCase() === feeTokenAddress &&
+          intent.task === IntentTask.TRANSFER_WALLET_TO_LINK
+        );
+      });
 
     for (const intent of action.intents) {
       const address = intent.type.payload.asset.address.toString();
@@ -205,11 +216,22 @@ export class FeeService {
 
       const decimals = token?.decimals ?? 8;
       const symbol = token?.symbol ?? "N/A";
-      const assetAmount =
+      let assetAmount =
         direction === FlowDirection.OUTGOING
           ? BigInt(intentFees.intent_total_amount) +
             BigInt(intentFees.intent_total_network_fee)
           : BigInt(intentFees.intent_total_amount);
+
+      // Effective total without double-counting: when the fee token (ICP) is also
+      // an outgoing asset for link funding, one ledger fee overlaps between the
+      // funding network fees and the link creation fee intent.
+      if (
+        feeType === FeeType.CREATE_LINK_FEE &&
+        address.toLowerCase() === feeTokenAddress &&
+        hasFeeTokenOutgoingAssetIntent
+      ) {
+        assetAmount = assetAmount > ledgerFee ? assetAmount - ledgerFee : 0n;
+      }
 
       const amountUi = parseBalanceUnits(assetAmount, decimals);
       const amountUsd = token?.priceUSD ? amountUi * token.priceUSD : undefined;
@@ -320,14 +342,12 @@ export class FeeService {
       const token = tokensMap[item.asset.address];
       if (!token) continue;
 
-      const amount =
-        item.fee.feeType === FeeType.CREATE_LINK_FEE
-          ? item.asset.amount
-          : item.fee.amount;
-      const usdAmount =
-        item.fee.feeType === FeeType.CREATE_LINK_FEE
-          ? parseFloat(item.asset.usdValueStr ?? "0")
-          : item.fee.usdValue;
+      const isCreateLinkFee = item.fee.feeType === FeeType.CREATE_LINK_FEE;
+
+      let amount = isCreateLinkFee ? item.asset.amount : item.fee.amount;
+      let usdAmount = isCreateLinkFee
+        ? parseFloat(item.asset.usdValueStr ?? "0")
+        : item.fee.usdValue;
 
       breakdown.push({
         name:
@@ -440,6 +460,10 @@ export class FeeService {
       return Err(new Error("Link fee token not found"));
     }
 
+    const isFeeTokenAlsoAsset = linkAssets.some(
+      (a) => a.address.toLowerCase() === linkFeeInfo.tokenAddress.toLowerCase(),
+    );
+
     const intentFees = calculateIntentFees({
       intent_participants: IntentParticipants.CreatorToTreasury,
       token_standard: TokenStandardMapper.toSharedType(
@@ -451,9 +475,18 @@ export class FeeService {
       link_creation_fee: linkFeeInfo.amount,
     });
 
-    const linkCreationFeeTotal =
+    // When fee token is also used as an asset, one ledger fee overlaps between
+    // the asset network fees and the link creation fee intent. Align preview
+    // with max-amount validation (and backend/shared calculations) by
+    // subtracting a single ledger fee from the displayed link creation fee.
+    const linkCreationFeeTotalRaw =
       BigInt(intentFees.intent_total_amount) +
       BigInt(intentFees.intent_total_network_fee);
+    const overlapFee = isFeeTokenAlsoAsset ? (linkFeeToken.fee ?? 0n) : 0n;
+    const linkCreationFeeTotal =
+      linkCreationFeeTotalRaw > overlapFee
+        ? linkCreationFeeTotalRaw - overlapFee
+        : 0n;
 
     const linkFeeFormatted = parseBalanceUnits(
       linkCreationFeeTotal,


### PR DESCRIPTION
Added detection for whether the fee token is also an outgoing asset in the link (hasFeeTokenOutgoingAssetIntent).
When computing the CREATE_LINK_FEE amount and the fee token overlaps with a link asset, one ledger fee (ledgerFee) is subtracted from the displayed creation fee to eliminate the double-count.

The same overlap correction is applied in the fee preview calculation (getLinkCreationFeeForPreview): an overlapFee equal to one ledger fee is subtracted from linkCreationFee when the fee token is also a link asset.