### PR TITLE
[Hotfix] Hotfix the gate-canister deployment

### DIFF
--- a/.github/workflows/deploy-canisters-dev.yml
+++ b/.github/workflows/deploy-canisters-dev.yml
@@ -57,4 +57,4 @@ jobs:
 
           just build dev
           # pass log filters to just dfx_deploy so canisters pick the appropriate level
-          just dfx_deploy "$owner" "--network=dev" "--mode=upgrade" "$backend_log_filter" "$token_storage_log_filter"
+          just dfx_deploy "$owner" "--network=dev" "$backend_log_filter" "$token_storage_log_filter"

--- a/just/dfx.just
+++ b/just/dfx.just
@@ -39,14 +39,14 @@ dfx_local_stop:
 # backend_log_filter: log filter string for the backend canister
 # token_storage_log_filter: log filter string for the token_storage canister
 [group('dfx')]
-dfx_deploy owner network="" mode="" backend_log_filter="" token_storage_log_filter="": 
+dfx_deploy owner network="" backend_log_filter="" token_storage_log_filter="" mode="": 
   #!/usr/bin/env bash
   set -e
   just dfx_deploy_token_storage {{owner}} {{network}} {{mode}} {{token_storage_log_filter}}
   just dfx_deploy_gate {{owner}} {{network}} {{mode}} {{backend_log_filter}}
   just dfx_deploy_backend {{owner}} {{network}} {{mode}} {{backend_log_filter}}
 
-  dfx deploy cashier_frontend_new {{network}} {{mode}} --upgrade-unchanged
+  dfx deploy cashier_frontend_new {{network}} {{mode}} --yes --upgrade-unchanged
 
 # Starts the local dfx server and deploys the canisters
 # params bitcoin: "true" to enable bitcoin node (for ckBTC flows), defaults to "false"


### PR DESCRIPTION
This PR includes the hotfix for the initial Gate canister deployment in the CI.
Issue:
- The CI currently fails to deploy Gate canister to dev , due to the fact that the Gate canister is only created without any wasm code, so the current mode upgrade specified in the CI command causes a failure deployment.

Solution:
- Ignore the mode option in the deployment command, leaving the ICP network selects the appropriate mode for the deployment.