### PR TITLE
[Hotfix] Dev canisters deployment

### DIFF
--- a/just/dfx.just
+++ b/just/dfx.just
@@ -42,9 +42,9 @@ dfx_local_stop:
 dfx_deploy owner network="" backend_log_filter="" token_storage_log_filter="" mode="": 
   #!/usr/bin/env bash
   set -e
-  just dfx_deploy_token_storage {{owner}} {{network}} {{mode}} {{token_storage_log_filter}}
-  just dfx_deploy_gate {{owner}} {{network}} {{mode}} {{backend_log_filter}}
-  just dfx_deploy_backend {{owner}} {{network}} {{mode}} {{backend_log_filter}}
+  just dfx_deploy_token_storage {{owner}} {{network}} {{token_storage_log_filter}} {{mode}}
+  just dfx_deploy_gate {{owner}} {{network}} {{backend_log_filter}} {{mode}}
+  just dfx_deploy_backend {{owner}} {{network}} {{backend_log_filter}} {{mode}}
 
   dfx deploy cashier_frontend_new {{network}} {{mode}} --yes --upgrade-unchanged
 
@@ -200,7 +200,7 @@ create_canisters network cycles:
 # mode: install, reinstall or upgrade
 # log_filter: log filter string (default for local and dev)
 [group('dfx')]
-dfx_deploy_backend owner network="" mode="" log_filter="global,cashier=debug":
+dfx_deploy_backend owner network="" log_filter="global,cashier=debug" mode="":
   #!/usr/bin/env bash
   set -e
 
@@ -221,7 +221,7 @@ dfx_deploy_backend owner network="" mode="" log_filter="global,cashier=debug":
 # mode: install, reinstall or upgrade
 # log_filter: log filter string (default for local and dev)
 [group('dfx')]
-dfx_deploy_token_storage owner network="" mode="" log_filter="global,cashier=debug,token_storage=debug":
+dfx_deploy_token_storage owner network="" log_filter="global,cashier=debug,token_storage=debug" mode="":
   #!/usr/bin/env bash
   set -e
 
@@ -240,7 +240,7 @@ dfx_deploy_token_storage owner network="" mode="" log_filter="global,cashier=deb
 # mode: install, reinstall or upgrade
 # log_filter: log filter string (default for local and dev)
 [group('dfx')]
-dfx_deploy_gate owner network="" mode="" log_filter="global,cashier=debug":
+dfx_deploy_gate owner network="" log_filter="global,cashier=debug" mode="":
   #!/usr/bin/env bash
   set -e
 


### PR DESCRIPTION
This PR includes the hotfix for dev canisters deployment.
Issue & fix:
The CI still fails to deploy canisters to DEV, due to the `mode` option incorrectly passed to the each canister's deployment command. The PR addressed the issue by placing the `mode` option properly.