### PR TITLE
Fixbug: transaction cart is not showing correct for use flow

### DIFF
--- a/src/cashier_frontend_new/src/modules/useLink/pages/use.svelte
+++ b/src/cashier_frontend_new/src/modules/useLink/pages/use.svelte
@@ -25,6 +25,7 @@
     shouldRedirectTo404,
   } from "$modules/useLink/utils/errorHandler";
   import { onDestroy, onMount } from "svelte";
+    import { ActionState } from "$shared/types";
 
   const {
     onIsLinkChange,
@@ -55,7 +56,8 @@
     return !!(
       userStore?.action !== null &&
       userStore?.link !== null &&
-      userStore?.action
+      userStore?.action && 
+      userStore.action.state != ActionState.Success
     );
   });
 
@@ -86,8 +88,6 @@
           locale.t("links.linkForm.useLink.errors.linkDetailMissing"),
         );
       }
-      // (Re)open the cart for this claim attempt.
-      isCartOpen = true;
 
       if (!userStore.action) {
         isCreatingAction = true;
@@ -101,6 +101,8 @@
 
         await userStore.createAction(actionType);
       }
+
+      isCartOpen = true;
     } catch (err) {
       // Check if error requires redirect to 404
       if (shouldRedirectErrorTo404(err, userStore.link ?? undefined)) {

--- a/src/cashier_frontend_new/src/modules/useLink/pages/use.svelte
+++ b/src/cashier_frontend_new/src/modules/useLink/pages/use.svelte
@@ -10,7 +10,6 @@
   import type { ProcessActionResult } from "$modules/detailLink/types/genericDetailStoreVM";
   import { getRouteContext } from "$modules/routing/state/routeContext.svelte";
   import { paths } from "$modules/routing/paths";
-  import { ActionState } from "$modules/links/types/action/actionState";
   import { UserLinkStep } from "$modules/links/types/userLinkStep";
   import { appHeaderStore } from "$modules/shared/state/appHeaderStore.svelte";
   import LinkTxCart from "$modules/transactionCart/components/LinkTxCart.svelte";
@@ -52,7 +51,13 @@
   let useWalletLockedTracked = $state(false);
   let useWalletUnlockedTracked = $state(false);
 
-  let isCartOpen = $state(true);
+  let isCartOpen = $derived.by(() => {
+    return !!(
+      userStore?.action !== null &&
+      userStore?.link !== null &&
+      userStore?.action
+    );
+  });
 
   const onCloseDrawer = () => {
     isCartOpen = false;
@@ -327,7 +332,7 @@
           {isCreatingAction}
           hasAction={!!userStore.action}
         />
-        {#if userStore?.link && userStore?.action && userStore.action.state !== ActionState.SUCCESS}
+        {#if userStore?.link && userStore?.action && isCartOpen}
           <LinkTxCart
             isOpen={isCartOpen}
             source={{

--- a/src/cashier_frontend_new/src/modules/useLink/pages/use.svelte
+++ b/src/cashier_frontend_new/src/modules/useLink/pages/use.svelte
@@ -52,16 +52,10 @@
   let useWalletLockedTracked = $state(false);
   let useWalletUnlockedTracked = $state(false);
 
-  let isTxCartOpen = $state(false);
-  let showTxCart = $derived.by(() => {
-    return (
-      isTxCartOpen &&
-      !!(userStore?.action && userStore.action.state !== ActionState.SUCCESS)
-    );
-  });
+  let isCartOpen = $state(true);
 
   const onCloseDrawer = () => {
-    isTxCartOpen = false;
+    isCartOpen = false;
   };
 
   const handleCreateUseAction = async () => {
@@ -87,9 +81,10 @@
           locale.t("links.linkForm.useLink.errors.linkDetailMissing"),
         );
       }
-      if (userStore.action) {
-        isTxCartOpen = true;
-      } else {
+      // (Re)open the cart for this claim attempt.
+      isCartOpen = true;
+
+      if (!userStore.action) {
         isCreatingAction = true;
         const actionType = userStore.findUseActionType();
 
@@ -100,9 +95,6 @@
         }
 
         await userStore.createAction(actionType);
-
-        await userStore.refreshAsync();
-        isTxCartOpen = true;
       }
     } catch (err) {
       // Check if error requires redirect to 404
@@ -335,9 +327,9 @@
           {isCreatingAction}
           hasAction={!!userStore.action}
         />
-        {#if showTxCart && userStore?.link && userStore?.action}
+        {#if userStore?.link && userStore?.action && userStore.action.state !== ActionState.SUCCESS}
           <LinkTxCart
-            isOpen={showTxCart}
+            isOpen={isCartOpen}
             source={{
               action: userStore.action,
               handleProcessAction,

--- a/src/cashier_frontend_new/src/modules/useLink/pages/use.svelte
+++ b/src/cashier_frontend_new/src/modules/useLink/pages/use.svelte
@@ -25,7 +25,7 @@
     shouldRedirectTo404,
   } from "$modules/useLink/utils/errorHandler";
   import { onDestroy, onMount } from "svelte";
-    import { ActionState } from "$shared/types";
+  import { ActionState } from "$shared/types";
 
   const {
     onIsLinkChange,
@@ -56,7 +56,7 @@
     return !!(
       userStore?.action !== null &&
       userStore?.link !== null &&
-      userStore?.action && 
+      userStore?.action &&
       userStore.action.state != ActionState.Success
     );
   });


### PR DESCRIPTION
Issue:
- In use flow, the transaction cart is not automatically popup when action existed or user click "Claim". It only popup when user click again

Updates:
- Simplify the logic for rendering transaction cart