### PR TITLE
[Hotfix] Resolve the DFX plaintext identity warning on invoking command

### DIFF
--- a/.github/workflows/gate-secrets-dev.yml
+++ b/.github/workflows/gate-secrets-dev.yml
@@ -65,6 +65,8 @@ jobs:
           EOF
 
       - name: Upload gate secrets
+        env:
+          DFX_WARNING: -mainnet_plaintext_identity
         run: node scripts/set-gate-secrets.mjs --mode ${{ inputs.mode }} --network dev
 
       - name: Clean up scripts/.env


### PR DESCRIPTION
Problem:
- On running command to call the gate canister, dfx rejected the call due to the plaintext imported identity. This issue is already resolved in dev canister deployment workflow, but it is missed in the new workflow.

Solution:
- Add the `mainnet_plaintext_identity` option to the dfx command to suppress the error.