### PR TITLE
[Hotfix] Post-actions failure

### DIFF
--- a/.github/actions/setup-node-pnpm/action.yml
+++ b/.github/actions/setup-node-pnpm/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Node + pnpm"
-description: "Installs pnpm and Node.js with pnpm-store caching enabled."
+description: "Installs pnpm and Node.js, with optional pnpm-store caching."
 
 inputs:
   node-version:
@@ -10,6 +10,14 @@ inputs:
     description: "pnpm version to install"
     required: false
     default: "10.6.2"
+  cache:
+    description: >-
+      Whether to cache pnpm's store. Only enable for jobs that actually run
+      `pnpm install` (directly or via `just`) afterwards — otherwise the store
+      directory never gets created, and the post-job cache-save step fails with
+      "Path(s) specified in the action for caching do(es) not exist."
+    required: false
+    default: "true"
 
 runs:
   using: "composite"
@@ -24,4 +32,4 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: "pnpm"
+        cache: ${{ inputs.cache == 'true' && 'pnpm' || '' }}

--- a/.github/workflows/gate-password-hashing-mode-dev.yml
+++ b/.github/workflows/gate-password-hashing-mode-dev.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          cache: "false"
 
       - name: Setup IC tooling
         uses: ./.github/actions/setup-ic-tools

--- a/.github/workflows/gate-secrets-dev.yml
+++ b/.github/workflows/gate-secrets-dev.yml
@@ -24,6 +24,10 @@ jobs:
 
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          # pnpm install only runs below in vetkd mode, so only cache then —
+          # otherwise the store never exists and the cache-save step fails.
+          cache: ${{ inputs.mode == 'vetkd' && 'true' || 'false' }}
 
       - name: Setup IC tooling
         uses: ./.github/actions/setup-ic-tools

--- a/.github/workflows/rate-limit-config-dev.yml
+++ b/.github/workflows/rate-limit-config-dev.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          cache: "false"
 
       - name: Setup IC tooling
         uses: ./.github/actions/setup-ic-tools

--- a/.github/workflows/token-storage-sync-collections-dev.yml
+++ b/.github/workflows/token-storage-sync-collections-dev.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Setup Node + pnpm
         uses: ./.github/actions/setup-node-pnpm
+        with:
+          cache: "false"
 
       - name: Setup IC tooling
         uses: ./.github/actions/setup-ic-tools


### PR DESCRIPTION
The problem:
- The post-actions failed due to not existing pnpm cache folder.

The root cause:
- Several workflows invoking the bare scripts such as sync-up-nft-collection never runs `pnpm install`, therefore doesn't create the cache, causing the cleanup command failure.

The fixes:
- Introduce a flag named `cache` in the setup action, set it false for the bare script workflow. The cleanup command is only invoked if the flag set true.