### PR TITLE
[Ticket #869ebh2tz] Display the intent state individually on transaction cart

### DIFF
--- a/src/cashier_backend_types/src/dto/action.rs
+++ b/src/cashier_backend_types/src/dto/action.rs
@@ -239,6 +239,8 @@ pub struct Icrc112Request {
     pub method: String,
     pub arg: Vec<u8>,
     pub nonce: Option<Vec<u8>>,
+    /// Ids of the intent(s) that produced this request.    
+    pub intent_ids: Vec<String>,
 }
 
 pub type ParallelRequests = Vec<Icrc112Request>;

--- a/src/cashier_frontend_new/src/lib/generated/cashier_backend/cashier_backend.did.d.ts
+++ b/src/cashier_frontend_new/src/lib/generated/cashier_backend/cashier_backend.did.d.ts
@@ -191,6 +191,7 @@ export interface Icrc112Request {
   'method' : string,
   'canister_id' : Principal,
   'nonce' : [] | [Uint8Array | number[]],
+  'intent_ids' : Array<string>,
 }
 export interface Icrc114ValidateArgs {
   'arg' : Uint8Array | number[],

--- a/src/cashier_frontend_new/src/lib/generated/cashier_backend/cashier_backend.did.js
+++ b/src/cashier_frontend_new/src/lib/generated/cashier_backend/cashier_backend.did.js
@@ -100,6 +100,7 @@ export const idlFactory = ({ IDL }) => {
     'method' : IDL.Text,
     'canister_id' : IDL.Principal,
     'nonce' : IDL.Opt(IDL.Vec(IDL.Nat8)),
+    'intent_ids' : IDL.Vec(IDL.Text),
   });
   const Chain = IDL.Variant({ 'IC' : IDL.Null });
   const IntentTask = IDL.Variant({

--- a/src/cashier_frontend_new/src/modules/auth/signer/ii/IIChannel.spec.ts
+++ b/src/cashier_frontend_new/src/modules/auth/signer/ii/IIChannel.spec.ts
@@ -1,0 +1,154 @@
+import type { BatchCallCanisterRequest } from "@slide-computer/signer";
+import { toBase64 } from "@slide-computer/signer";
+import { describe, expect, it, vi } from "vitest";
+
+const { pollForResponseMock, certificateCreateMock, cborEncodeMock } =
+  vi.hoisted(() => ({
+    pollForResponseMock: vi.fn().mockResolvedValue(undefined),
+    certificateCreateMock: vi.fn(),
+    cborEncodeMock: vi.fn().mockReturnValue(new Uint8Array([1, 2, 3])),
+  }));
+
+vi.mock("@icp-sdk/core/agent", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@icp-sdk/core/agent")>();
+
+  class FakeHttpAgent {
+    rootKey = new Uint8Array([0]);
+    #transform?: (req: { body: unknown }) => unknown;
+
+    addTransform(_kind: string, cb: (req: { body: unknown }) => unknown) {
+      this.#transform = cb;
+    }
+
+    async call(_canisterId: unknown, opts: { methodName: string }) {
+      await this.#transform?.({ body: {} });
+      // Deterministically fail the "test_method_b" request so tests can
+      // assert on a mixed success/error batch without depending on
+      // parallel-execution ordering.
+      if (opts.methodName === "test_method_b") {
+        throw new Error("simulated call failure");
+      }
+      return { requestId: new Uint8Array([1]) };
+    }
+
+    async readState() {
+      return { certificate: new Uint8Array([9, 9, 9]) };
+    }
+
+    static async from() {
+      return new FakeHttpAgent();
+    }
+  }
+
+  return {
+    ...actual,
+    Actor: { createActor: vi.fn() },
+    Cbor: { encode: cborEncodeMock },
+    Certificate: { create: certificateCreateMock },
+    HttpAgent: FakeHttpAgent,
+    LookupPathStatus: { Found: "Found", Unknown: "Unknown", Absent: "Absent" },
+    polling: { pollForResponse: pollForResponseMock },
+  };
+});
+
+import type { HttpAgent } from "@icp-sdk/core/agent";
+import { IIChannel } from "$modules/auth/signer/ii/IIChannel";
+import type { BatchCallProgress } from "$modules/auth/signer/types";
+
+function buildBatchRequest(): BatchCallCanisterRequest {
+  // A single sequence group with two parallel requests: with only one
+  // top-level (sequence) entry, no validation canister is required (the
+  // implementation's "validation required" check only triggers when there is
+  // more than one sequence group).
+  return {
+    jsonrpc: "2.0",
+    id: "batch-1",
+    method: "icrc112_batch_call_canister",
+    params: {
+      sender: "aaaaa-aa",
+      requests: [
+        [
+          {
+            canisterId: "aaaaa-aa",
+            method: "test_method_a",
+            arg: toBase64(new Uint8Array([1])),
+          },
+          {
+            canisterId: "aaaaa-aa",
+            method: "test_method_b",
+            arg: toBase64(new Uint8Array([2])),
+          },
+        ],
+      ],
+    },
+  };
+}
+
+describe("IIChannel batch progress", () => {
+  it("notifies onBatchProgress once per sub-request, before the aggregate response event", async () => {
+    certificateCreateMock.mockResolvedValue({
+      lookup_path: (path: string[]) => {
+        const last = path[path.length - 1];
+        if (last === "status") {
+          return {
+            status: "Found",
+            value: new TextEncoder().encode("replied"),
+          };
+        }
+        return { status: "Found", value: new Uint8Array([1]) };
+      },
+    });
+
+    const channel = new IIChannel({} as unknown as HttpAgent);
+    const events: string[] = [];
+    const progress: BatchCallProgress[] = [];
+
+    channel.onBatchProgress((p) => {
+      progress.push(p);
+      events.push("progress");
+    });
+    channel.addEventListener("response", () => {
+      events.push("response");
+    });
+
+    await channel.send(buildBatchRequest());
+
+    // "test_method_a" (parallelIndex 0) succeeds, "test_method_b" (parallelIndex 1)
+    // is made to fail (see FakeHttpAgent.call) - both run in the same parallel
+    // group, so we match by content rather than assuming resolution order.
+    expect(progress).toHaveLength(2);
+    const successEvent = progress.find((p) => "result" in p.response);
+    const errorEvent = progress.find((p) => "error" in p.response);
+    expect(successEvent).toMatchObject({ sequenceIndex: 0, parallelIndex: 0 });
+    expect(errorEvent).toMatchObject({ sequenceIndex: 0, parallelIndex: 1 });
+
+    // Progress fires per-request, strictly before the aggregate "response" event.
+    expect(events.filter((e) => e === "progress")).toHaveLength(2);
+    expect(events.at(-1)).toBe("response");
+    expect(events.indexOf("response")).toBe(events.length - 1);
+  });
+
+  it("unsubscribe stops further notifications", async () => {
+    certificateCreateMock.mockResolvedValue({
+      lookup_path: (path: string[]) => {
+        const last = path[path.length - 1];
+        if (last === "status") {
+          return {
+            status: "Found",
+            value: new TextEncoder().encode("replied"),
+          };
+        }
+        return { status: "Found", value: new Uint8Array([1]) };
+      },
+    });
+
+    const channel = new IIChannel({} as unknown as HttpAgent);
+    const progress: BatchCallProgress[] = [];
+    const unsubscribe = channel.onBatchProgress((p) => progress.push(p));
+    unsubscribe();
+
+    await channel.send(buildBatchRequest());
+
+    expect(progress).toHaveLength(0);
+  });
+});

--- a/src/cashier_frontend_new/src/modules/auth/signer/ii/IIChannel.ts
+++ b/src/cashier_frontend_new/src/modules/auth/signer/ii/IIChannel.ts
@@ -32,6 +32,7 @@ import {
   scopes,
   supportedStandards,
 } from "$modules/auth/signer/ii/constants";
+import type { BatchCallProgress } from "$modules/auth/signer/types";
 
 // TODO: Remove this if all PRs resolve
 // - https://github.com/slide-computer/signer-js/pull/9
@@ -57,6 +58,9 @@ export class IIChannel implements Channel {
   readonly #agent: HttpAgent;
   readonly #closeListeners = new Set<() => void>();
   readonly #responseListeners = new Set<(response: JsonResponse) => void>();
+  readonly #batchProgressListeners = new Set<
+    (progress: BatchCallProgress) => void
+  >();
   #closed: boolean = false;
 
   constructor(agent: HttpAgent) {
@@ -65,6 +69,29 @@ export class IIChannel implements Channel {
 
   get closed() {
     return this.#closed;
+  }
+
+  /**
+   * Additive hook (not part of the `Channel` interface): notified once per
+   * individual sub-request inside an `icrc112_batch_call_canister` call, as
+   * soon as *that* request settles - independent of the aggregate "response"
+   * event, which only fires once the whole batch (all sequences) has
+   * finished. Consumers must feature-detect this method.
+   * @param listener - callback invoked with a `BatchCallProgress` object
+   */
+  onBatchProgress(listener: (progress: BatchCallProgress) => void): () => void {
+    this.#batchProgressListeners.add(listener);
+    return () => {
+      this.#batchProgressListeners.delete(listener);
+    };
+  }
+
+  /**
+   * Notify all batch progress listeners.
+   * @param progress - the progress object to send to listeners
+   */
+  #notifyBatchProgress(progress: BatchCallProgress): void {
+    this.#batchProgressListeners.forEach((listener) => listener(progress));
   }
 
   /**
@@ -344,97 +371,138 @@ export class IIChannel implements Channel {
           },
         };
         let batchFailed = false;
-        for (const requests of batchCallCanisterRequest.params!.requests) {
+        for (const [
+          sequenceIndex,
+          requests,
+        ] of batchCallCanisterRequest.params!.requests.entries()) {
           // v5: Per-request error responses retain shape from prior versions; cast to satisfy stricter response type
           batchCallCanisterResponse.result.responses.push(
             (await Promise.all(
-              requests.map(async (request) => {
-                if (batchFailed) {
-                  return {
-                    error: {
-                      code: 1001,
-                      message: "Request not processed.",
-                    },
-                  };
-                }
-                try {
-                  const canisterId = Principal.fromText(request.canisterId);
-                  // v5: clone agent per request to avoid accumulating addTransform handlers
-                  // on the shared #agent across batch iterations
-                  const agent = await HttpAgent.from(this.#agent);
-                  // v5: Cbor.encode returns Uint8Array (was ArrayBuffer)
-                  let contentMap: Uint8Array =
-                    undefined as unknown as Uint8Array;
-                  agent.addTransform("update", async (agentRequest) => {
-                    contentMap = Cbor.encode(agentRequest.body);
-                    return agentRequest;
-                  });
-                  const submitResponse = await agent.call(canisterId, {
-                    effectiveCanisterId: canisterId,
-                    methodName: request.method,
-                    arg: fromBase64(request.arg),
-                  });
-                  // v5: pollForResponse signature uses PollingOptions, default {} works
-                  await pollForResponse(
-                    agent,
-                    canisterId,
-                    submitResponse.requestId,
-                  );
-                  const { certificate } = await agent.readState(canisterId, {
-                    // v5: readState path elements must be Uint8Array
-                    paths: [
-                      [
-                        new TextEncoder().encode("request_status"),
-                        submitResponse.requestId,
-                      ],
-                    ],
-                  });
-                  // v5: Certificate.create takes principal: { canisterId } (was canisterId)
-                  // agent.rootKey may be ArrayBuffer | Uint8Array; coerce to Uint8Array
-                  const rootKey = (agent.rootKey ??
-                    MAINNET_ROOT_KEY) as Uint8Array;
-                  const validCertificate = await Certificate.create({
-                    certificate,
-                    rootKey,
-                    principal: { canisterId },
-                  });
-                  // v5: lookup_path replaces lookup for leaf value semantics
-                  const status = validCertificate.lookup_path([
-                    "request_status",
-                    submitResponse.requestId,
-                    "status",
-                  ]);
-                  const reply = validCertificate.lookup_path([
-                    "request_status",
-                    submitResponse.requestId,
-                    "reply",
-                  ]);
-                  if (
-                    status.status !== LookupPathStatus.Found ||
-                    new TextDecoder().decode(status.value) !== "replied" ||
-                    reply.status !== LookupPathStatus.Found
-                  ) {
-                    batchFailed = true;
+              requests.map(async (request, parallelIndex) => {
+                const response = await (async () => {
+                  if (batchFailed) {
                     return {
                       error: {
-                        code: 4000,
-                        message: "Certificate is missing reply.",
+                        code: 1001,
+                        message: "Request not processed.",
                       },
                     };
                   }
-                  if (
-                    request.method.startsWith("icrc1_") ||
-                    request.method.startsWith("icrc2_") ||
-                    request.method.startsWith("icrc7_") ||
-                    request.method.startsWith("icrc37_")
-                  ) {
-                    // Built in validation, basically checks if variant with Err is returned
-                    try {
-                      const value = IDL.decode(
-                        [IDL.Variant({ Err: IDL.Reserved })],
-                        reply.value,
-                      );
-                      if ("Err" in value) {
+                  try {
+                    const canisterId = Principal.fromText(request.canisterId);
+                    // v5: clone agent per request to avoid accumulating addTransform handlers
+                    // on the shared #agent across batch iterations
+                    const agent = await HttpAgent.from(this.#agent);
+                    // v5: Cbor.encode returns Uint8Array (was ArrayBuffer)
+                    let contentMap: Uint8Array =
+                      undefined as unknown as Uint8Array;
+                    agent.addTransform("update", async (agentRequest) => {
+                      contentMap = Cbor.encode(agentRequest.body);
+                      return agentRequest;
+                    });
+                    const submitResponse = await agent.call(canisterId, {
+                      effectiveCanisterId: canisterId,
+                      methodName: request.method,
+                      arg: fromBase64(request.arg),
+                    });
+                    // v5: pollForResponse signature uses PollingOptions, default {} works
+                    await pollForResponse(
+                      agent,
+                      canisterId,
+                      submitResponse.requestId,
+                    );
+                    const { certificate } = await agent.readState(canisterId, {
+                      // v5: readState path elements must be Uint8Array
+                      paths: [
+                        [
+                          new TextEncoder().encode("request_status"),
+                          submitResponse.requestId,
+                        ],
+                      ],
+                    });
+                    // v5: Certificate.create takes principal: { canisterId } (was canisterId)
+                    // agent.rootKey may be ArrayBuffer | Uint8Array; coerce to Uint8Array
+                    const rootKey = (agent.rootKey ??
+                      MAINNET_ROOT_KEY) as Uint8Array;
+                    const validCertificate = await Certificate.create({
+                      certificate,
+                      rootKey,
+                      principal: { canisterId },
+                    });
+                    // v5: lookup_path replaces lookup for leaf value semantics
+                    const status = validCertificate.lookup_path([
+                      "request_status",
+                      submitResponse.requestId,
+                      "status",
+                    ]);
+                    const reply = validCertificate.lookup_path([
+                      "request_status",
+                      submitResponse.requestId,
+                      "reply",
+                    ]);
+                    if (
+                      status.status !== LookupPathStatus.Found ||
+                      new TextDecoder().decode(status.value) !== "replied" ||
+                      reply.status !== LookupPathStatus.Found
+                    ) {
+                      batchFailed = true;
+                      return {
+                        error: {
+                          code: 4000,
+                          message: "Certificate is missing reply.",
+                        },
+                      };
+                    }
+                    if (
+                      request.method.startsWith("icrc1_") ||
+                      request.method.startsWith("icrc2_") ||
+                      request.method.startsWith("icrc7_") ||
+                      request.method.startsWith("icrc37_")
+                    ) {
+                      // Built in validation, basically checks if variant with Err is returned
+                      try {
+                        const value = IDL.decode(
+                          [IDL.Variant({ Err: IDL.Reserved })],
+                          reply.value,
+                        );
+                        if ("Err" in value) {
+                          batchFailed = true;
+                          return {
+                            error: {
+                              code: 1003,
+                              message: "Validation failed.",
+                            },
+                          };
+                        }
+                      } catch {
+                        // If this return error likely the response is not included Err variant
+                        // so we can assume it's valid
+                        return {
+                          result: {
+                            contentMap: toBase64(contentMap!),
+                            certificate: toBase64(certificate),
+                          },
+                        };
+                      }
+                    }
+
+                    if (validationActor) {
+                      const icrc114Args: Icrc114ValidateArgs = {
+                        canister_id: Principal.fromText(request.canisterId),
+                        method: request.method,
+                        arg: new Uint8Array(fromBase64(request.arg)),
+                        res: reply.value,
+                        nonce: request.nonce
+                          ? [new Uint8Array(fromBase64(request.nonce))]
+                          : [],
+                      };
+
+                      const isValid =
+                        await validationActor[ICRC_114_METHOD_NAME](
+                          icrc114Args,
+                        );
+
+                      if (!isValid) {
                         batchFailed = true;
                         return {
                           error: {
@@ -443,59 +511,33 @@ export class IIChannel implements Channel {
                           },
                         };
                       }
-                    } catch {
-                      // If this return error likely the response is not included Err variant
-                      // so we can assume it's valid
-                      return {
-                        result: {
-                          contentMap: toBase64(contentMap!),
-                          certificate: toBase64(certificate),
-                        },
-                      };
                     }
-                  }
-
-                  if (validationActor) {
-                    const icrc114Args: Icrc114ValidateArgs = {
-                      canister_id: Principal.fromText(request.canisterId),
-                      method: request.method,
-                      arg: new Uint8Array(fromBase64(request.arg)),
-                      res: reply.value,
-                      nonce: request.nonce
-                        ? [new Uint8Array(fromBase64(request.nonce))]
-                        : [],
+                    return {
+                      result: {
+                        contentMap: toBase64(contentMap!),
+                        certificate: toBase64(certificate),
+                      },
                     };
-
-                    const isValid =
-                      await validationActor[ICRC_114_METHOD_NAME](icrc114Args);
-
-                    if (!isValid) {
-                      batchFailed = true;
-                      return {
-                        error: {
-                          code: 1003,
-                          message: "Validation failed.",
-                        },
-                      };
-                    }
+                  } catch (error) {
+                    console.error("Error processing request:", error);
+                    batchFailed = true;
+                    return {
+                      error: {
+                        code: 4000,
+                        message: "Request failed.",
+                        data:
+                          error instanceof Error ? error.message : undefined,
+                      },
+                    };
                   }
-                  return {
-                    result: {
-                      contentMap: toBase64(contentMap!),
-                      certificate: toBase64(certificate),
-                    },
-                  };
-                } catch (error) {
-                  console.error("Error processing request:", error);
-                  batchFailed = true;
-                  return {
-                    error: {
-                      code: 4000,
-                      message: "Request failed.",
-                      data: error instanceof Error ? error.message : undefined,
-                    },
-                  };
-                }
+                })();
+                this.#notifyBatchProgress({
+                  sequenceIndex,
+                  parallelIndex,
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  response: response as any,
+                });
+                return response;
               }),
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
             )) as any,

--- a/src/cashier_frontend_new/src/modules/auth/signer/types.ts
+++ b/src/cashier_frontend_new/src/modules/auth/signer/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Result of a single sub-request settling inside an `icrc112_batch_call_canister`
+ * batch, identified by its position within the 2D sequence/parallel request array.
+ */
+export type BatchCallProgress = {
+  sequenceIndex: number;
+  parallelIndex: number;
+  response:
+    | { result: { contentMap: string; certificate: string } }
+    | { error: { code: number; message: string; data?: unknown } };
+};
+
+/**
+ * Structural type for channels that support the additive `onBatchProgress`
+ * hook, so consumers (e.g. `Icrc112Service`) can feature-detect it without a
+ * hard dependency on any concrete signer's channel implementation.
+ */
+export type ChannelWithBatchProgress = {
+  onBatchProgress: (
+    listener: (progress: BatchCallProgress) => void,
+  ) => () => void;
+};

--- a/src/cashier_frontend_new/src/modules/icrc112/services/icrc112Service.spec.ts
+++ b/src/cashier_frontend_new/src/modules/icrc112/services/icrc112Service.spec.ts
@@ -1,0 +1,141 @@
+import { Principal } from "@icp-sdk/core/principal";
+import type {
+  BatchCallCanisterResponse,
+  Signer,
+  Transport,
+} from "@slide-computer/signer";
+import { describe, expect, it, vi } from "vitest";
+import type { BatchCallProgress } from "$modules/auth/signer/types";
+import Icrc112Service from "$modules/icrc112/services/icrc112Service";
+
+const CANISTER_ID = Principal.fromText("aaaaa-aa");
+
+function buildRequests(intentIdsA: string[], intentIdsB: string[]) {
+  return [
+    [
+      {
+        canister_id: CANISTER_ID,
+        method: "icrc2_approve",
+        arg: new ArrayBuffer(0),
+        intentIds: intentIdsA,
+      },
+      {
+        canister_id: CANISTER_ID,
+        method: "icrc1_transfer",
+        arg: new ArrayBuffer(0),
+        intentIds: intentIdsB,
+      },
+    ],
+  ];
+}
+
+function successResponse(): BatchCallCanisterResponse {
+  return {
+    id: "id",
+    jsonrpc: "2.0",
+    result: {
+      responses: [
+        [
+          { result: { contentMap: "a", certificate: "b" } },
+          { result: { contentMap: "c", certificate: "d" } },
+        ],
+      ],
+    },
+  } as unknown as BatchCallCanisterResponse;
+}
+
+describe("Icrc112Service.sendBatchRequest", () => {
+  it("calls onRequestSettled once per position with correct intentIds and success flags", async () => {
+    let capturedListener: ((p: BatchCallProgress) => void) | undefined;
+    const unsubscribe = vi.fn();
+    const channel = {
+      onBatchProgress: vi.fn((listener: (p: BatchCallProgress) => void) => {
+        capturedListener = listener;
+        return unsubscribe;
+      }),
+    };
+    const sendRequest = vi.fn().mockImplementation(async () => {
+      // Simulate the signer/channel emitting progress before the aggregate resolves.
+      capturedListener?.({
+        sequenceIndex: 0,
+        parallelIndex: 0,
+        response: { result: { contentMap: "a", certificate: "b" } },
+      });
+      capturedListener?.({
+        sequenceIndex: 0,
+        parallelIndex: 1,
+        response: { error: { code: 4000, message: "failed" } },
+      });
+      return successResponse();
+    });
+    const signer = {
+      openChannel: vi.fn().mockResolvedValue(channel),
+      sendRequest,
+    } as unknown as Signer<Transport>;
+
+    const service = new Icrc112Service(signer);
+    const onRequestSettled = vi.fn();
+
+    const result = await service.sendBatchRequest(
+      buildRequests(["intent-1"], ["intent-2", "intent-3"]),
+      "sender-principal",
+      "cashier-backend-id",
+      onRequestSettled,
+    );
+
+    expect(result.isSuccess).toBe(true);
+    expect(onRequestSettled).toHaveBeenCalledTimes(2);
+    expect(onRequestSettled).toHaveBeenNthCalledWith(
+      1,
+      ["intent-1"],
+      true,
+      undefined,
+    );
+    expect(onRequestSettled).toHaveBeenNthCalledWith(
+      2,
+      ["intent-2", "intent-3"],
+      false,
+      JSON.stringify({ code: 4000, message: "failed" }),
+    );
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it("does not subscribe to channel progress when no callback is provided", async () => {
+    const channel = { onBatchProgress: vi.fn() };
+    const signer = {
+      openChannel: vi.fn().mockResolvedValue(channel),
+      sendRequest: vi.fn().mockResolvedValue(successResponse()),
+    } as unknown as Signer<Transport>;
+
+    const service = new Icrc112Service(signer);
+    await service.sendBatchRequest(
+      buildRequests(["intent-1"], ["intent-2"]),
+      "sender-principal",
+      "cashier-backend-id",
+    );
+
+    expect(signer.openChannel).not.toHaveBeenCalled();
+    expect(channel.onBatchProgress).not.toHaveBeenCalled();
+  });
+
+  it("gracefully degrades when the channel does not support onBatchProgress", async () => {
+    const channel = {};
+    const signer = {
+      openChannel: vi.fn().mockResolvedValue(channel),
+      sendRequest: vi.fn().mockResolvedValue(successResponse()),
+    } as unknown as Signer<Transport>;
+
+    const service = new Icrc112Service(signer);
+    const onRequestSettled = vi.fn();
+
+    const result = await service.sendBatchRequest(
+      buildRequests(["intent-1"], ["intent-2"]),
+      "sender-principal",
+      "cashier-backend-id",
+      onRequestSettled,
+    );
+
+    expect(result.isSuccess).toBe(true);
+    expect(onRequestSettled).not.toHaveBeenCalled();
+  });
+});

--- a/src/cashier_frontend_new/src/modules/icrc112/services/icrc112Service.ts
+++ b/src/cashier_frontend_new/src/modules/icrc112/services/icrc112Service.ts
@@ -6,7 +6,11 @@ import {
   type Transport,
   toBase64,
 } from "@slide-computer/signer";
-import type { Icrc112ExecutionResult } from "$modules/icrc112/types/icrc112Request";
+import type {
+  Icrc112ExecutionResult,
+  OnRequestSettled,
+} from "$modules/icrc112/types/icrc112Request";
+import { hasBatchProgress } from "$modules/icrc112/utils/hasBatchProgress";
 
 // Class of service handler for ICRC-112 requests
 // T is the Transport type used by the Signer
@@ -20,6 +24,9 @@ class Icrc112Service<T extends Transport> {
   /**
    * Send ICRC-112 batch call request using the connected signer
    * @param icrc112Requests - 2D array of ICRC-112 requests (sequences of parallel requests)
+   * @param sender - Principal text of the sender
+   * @param cashierBackendCanisterId - Canister id used for ICRC-114 validation
+   * @param onRequestSettled - Optional callback invoked as each individual sub-request settles
    * @returns The result of the ICRC-112 execution
    */
   async sendBatchRequest(
@@ -29,10 +36,12 @@ class Icrc112Service<T extends Transport> {
         method: string;
         arg: Uint8Array | ArrayBuffer;
         nonce?: Uint8Array | ArrayBuffer;
+        intentIds?: string[];
       }>
     >,
     sender: string,
     cashierBackendCanisterId: string,
+    onRequestSettled?: OnRequestSettled,
   ): Promise<Icrc112ExecutionResult> {
     const requests = icrc112Requests.map((parallelRequests) =>
       parallelRequests.map((request) => {
@@ -65,6 +74,27 @@ class Icrc112Service<T extends Transport> {
         validationCanisterId: cashierBackendCanisterId,
       },
     };
+
+    const intentIdsByPosition = icrc112Requests.map((group) =>
+      group.map((r) => r.intentIds ?? []),
+    );
+
+    let unsubscribeBatchProgress: (() => void) | undefined;
+    if (onRequestSettled) {
+      const channel = await this.signer.openChannel();
+      if (hasBatchProgress(channel)) {
+        unsubscribeBatchProgress = channel.onBatchProgress(
+          ({ sequenceIndex, parallelIndex, response }) => {
+            const intentIds =
+              intentIdsByPosition[sequenceIndex]?.[parallelIndex] ?? [];
+            const success = "result" in response;
+            const error =
+              "error" in response ? JSON.stringify(response.error) : undefined;
+            onRequestSettled(intentIds, success, error);
+          },
+        );
+      }
+    }
 
     try {
       const res = await this.signer.sendRequest<
@@ -129,6 +159,8 @@ class Icrc112Service<T extends Transport> {
         isSuccess: false,
         errors: [error instanceof Error ? error.message : String(error)],
       };
+    } finally {
+      unsubscribeBatchProgress?.();
     }
   }
 }

--- a/src/cashier_frontend_new/src/modules/icrc112/types/icrc112Request.spec.ts
+++ b/src/cashier_frontend_new/src/modules/icrc112/types/icrc112Request.spec.ts
@@ -11,10 +11,26 @@ describe("Icrc112Request.fromBackendType", () => {
       method: "m",
       canister_id: p,
       nonce: [new Uint8Array([7, 8])],
+      intent_ids: ["intent-1", "intent-2"],
     };
 
     const r = Icrc112RequestMapper.fromBackendType(backend);
     expect(r.method).toBe("m");
     expect(r.canister_id.toText()).toBe(p.toText());
+    expect(r.intentIds).toEqual(["intent-1", "intent-2"]);
+  });
+
+  it("defaults intentIds to an empty array when absent", () => {
+    const p = Principal.fromText("ryjl3-tyaaa-aaaaa-aaaba-cai");
+    const backend: BackendIcrc112Request = {
+      arg: [1, 2, 3],
+      method: "m",
+      canister_id: p,
+      nonce: [],
+      intent_ids: [],
+    };
+
+    const r = Icrc112RequestMapper.fromBackendType(backend);
+    expect(r.intentIds).toEqual([]);
   });
 });

--- a/src/cashier_frontend_new/src/modules/icrc112/types/icrc112Request.ts
+++ b/src/cashier_frontend_new/src/modules/icrc112/types/icrc112Request.ts
@@ -11,6 +11,7 @@ class Icrc112Request {
     public method: string,
     public canister_id: Principal,
     public nonce?: ArrayBuffer,
+    public intentIds: string[] = [],
   ) {}
 }
 
@@ -42,6 +43,7 @@ export class Icrc112RequestMapper {
       method: b.method,
       canister_id: b.canister_id,
       nonce: nonceArray as ArrayBuffer | undefined,
+      intentIds: b.intent_ids ?? [],
     };
   }
 }
@@ -50,3 +52,13 @@ export type Icrc112ExecutionResult = {
   isSuccess: boolean;
   errors: string[] | null;
 };
+
+/** Called once per individual ICRC-112 sub-request as it settles, before the
+ * aggregate batch result resolves. `intentIds` are the intent(s) the settled
+ * request belongs to (may contain more than one when the backend merged
+ * transactions from different intents into a single request). */
+export type OnRequestSettled = (
+  intentIds: string[],
+  success: boolean,
+  error?: string,
+) => void;

--- a/src/cashier_frontend_new/src/modules/icrc112/utils/hasBatchProgress.spec.ts
+++ b/src/cashier_frontend_new/src/modules/icrc112/utils/hasBatchProgress.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { hasBatchProgress } from "$modules/icrc112/utils/hasBatchProgress";
+
+describe("hasBatchProgress", () => {
+  it("returns true when the channel exposes an onBatchProgress function", () => {
+    const channel = { onBatchProgress: vi.fn() };
+    expect(hasBatchProgress(channel)).toBe(true);
+  });
+
+  it("returns false when the channel has no onBatchProgress property", () => {
+    const channel = {};
+    expect(hasBatchProgress(channel)).toBe(false);
+  });
+
+  it("returns false when onBatchProgress is not a function", () => {
+    const channel = { onBatchProgress: "not-a-function" };
+    expect(hasBatchProgress(channel)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(hasBatchProgress(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(hasBatchProgress(undefined)).toBe(false);
+  });
+
+  it("returns false for non-object primitives", () => {
+    expect(hasBatchProgress("channel")).toBe(false);
+    expect(hasBatchProgress(42)).toBe(false);
+    expect(hasBatchProgress(true)).toBe(false);
+  });
+});

--- a/src/cashier_frontend_new/src/modules/icrc112/utils/hasBatchProgress.ts
+++ b/src/cashier_frontend_new/src/modules/icrc112/utils/hasBatchProgress.ts
@@ -1,0 +1,18 @@
+import type { ChannelWithBatchProgress } from "$modules/auth/signer/types";
+
+/**
+ * Type guard: does this channel support the additive `onBatchProgress` hook?
+ * Lets callers (e.g. `Icrc112Service`) feature-detect per-request progress
+ * without a hard dependency on any concrete signer's channel implementation.
+ * @param channel - the channel instance to check
+ */
+export function hasBatchProgress(
+  channel: unknown,
+): channel is ChannelWithBatchProgress {
+  return (
+    typeof channel === "object" &&
+    channel !== null &&
+    typeof (channel as Partial<ChannelWithBatchProgress>).onBatchProgress ===
+      "function"
+  );
+}

--- a/src/cashier_frontend_new/src/modules/transactionCart/state/linkTxCartStore.spec.ts
+++ b/src/cashier_frontend_new/src/modules/transactionCart/state/linkTxCartStore.spec.ts
@@ -278,6 +278,7 @@ describe("LinkTxCartStore", () => {
         source.action.icrc_112_requests,
         "test-principal-id",
         CASHIER_BACKEND_CANISTER_ID,
+        expect.any(Function),
       );
       expect(source.handleProcessAction).toHaveBeenCalled();
     });
@@ -374,6 +375,24 @@ describe("LinkTxCartStore", () => {
 
     it("should_set_phase3_on_success", async () => {
       const source = createActionSource(true);
+      vi.mocked(source.handleProcessAction).mockResolvedValue({
+        action: {
+          ...createMockAction(),
+          intents: [
+            {
+              id: "intent-1",
+              type: "TRANSFER",
+              state: "SUCCESS",
+              payload: {
+                amount: 1_000_000n,
+                token: "ryjl3-tyaaa-aaaaa-aaaba-cai",
+              },
+            },
+          ],
+        } as unknown as Action,
+        isSuccess: true,
+        errors: [],
+      } as ProcessActionResult);
       const store = new LinkTxCartStore(source);
       mockMapActionToAssetAndFeeList.mockReturnValue([
         {
@@ -391,6 +410,34 @@ describe("LinkTxCartStore", () => {
       await store.execute();
 
       expect(store.phase).toBe(TxProgressPhase.COMPLETED);
+      expect(store.assetAndFeeList[0].asset.state).toBe(
+        AssetProcessState.SUCCEED,
+      );
+    });
+
+    it("should_fall_back_to_blanket_succeed_when_no_action_returned", async () => {
+      const source = createActionSource(true);
+      vi.mocked(source.handleProcessAction).mockResolvedValue({
+        action: undefined,
+        isSuccess: true,
+        errors: [],
+      } as unknown as ProcessActionResult);
+      const store = new LinkTxCartStore(source);
+      mockMapActionToAssetAndFeeList.mockReturnValue([
+        {
+          asset: {
+            state: AssetProcessState.CREATED,
+            intentId: "intent-1",
+            symbol: "ICP",
+          },
+          fee: null,
+        },
+      ]);
+      store.initializeAssets({});
+      store.initialize();
+
+      await store.execute();
+
       expect(store.assetAndFeeList[0].asset.state).toBe(
         AssetProcessState.SUCCEED,
       );
@@ -422,6 +469,132 @@ describe("LinkTxCartStore", () => {
       await expect(store.execute()).rejects.toThrow("backend error");
 
       expect(store.phase).toBe(TxProgressPhase.IDLE);
+    });
+  });
+
+  describe("applyBatchProgress via ICRC-112 execution", () => {
+    function mockTwoRowAssets() {
+      mockMapActionToAssetAndFeeList.mockReturnValue([
+        {
+          asset: {
+            state: AssetProcessState.CREATED,
+            intentId: "intent-1",
+            symbol: "ICP",
+          },
+          fee: null,
+        },
+        {
+          asset: {
+            state: AssetProcessState.CREATED,
+            intentId: "intent-2",
+            symbol: "KONG",
+          },
+          fee: null,
+        },
+      ]);
+    }
+
+    it("should_flip_only_the_matching_row_when_one_sub_request_settles_mid_flight", async () => {
+      let resolveIcrc: (v: { isSuccess: boolean }) => void;
+      const icrcPromise = new Promise<{ isSuccess: boolean }>((resolve) => {
+        resolveIcrc = resolve;
+      });
+      mockSendBatchRequest.mockReturnValueOnce(icrcPromise);
+
+      const source = createActionSource(true);
+      const store = new LinkTxCartStore(source);
+      mockTwoRowAssets();
+      store.initializeAssets({});
+      store.initialize();
+
+      const executePromise = store.execute();
+      await vi.waitFor(() => store.phase === TxProgressPhase.FE_PHASE);
+
+      // Grab the onRequestSettled callback passed as the 4th arg and invoke it
+      // as if only intent-1's sub-request has settled so far.
+      const onRequestSettled = mockSendBatchRequest.mock.calls[0][3] as (
+        intentIds: string[],
+        success: boolean,
+      ) => void;
+      onRequestSettled(["intent-1"], true);
+
+      expect(store.assetAndFeeList[0].asset.state).toBe(
+        AssetProcessState.SIGNED_PENDING,
+      );
+      expect(store.assetAndFeeList[1].asset.state).toBe(
+        AssetProcessState.PROCESSING,
+      );
+
+      resolveIcrc!({ isSuccess: true });
+      await executePromise;
+    });
+
+    it("should_flip_all_matching_rows_together_when_a_merged_request_settles", async () => {
+      let resolveIcrc: (v: { isSuccess: boolean }) => void;
+      const icrcPromise = new Promise<{ isSuccess: boolean }>((resolve) => {
+        resolveIcrc = resolve;
+      });
+      mockSendBatchRequest.mockReturnValueOnce(icrcPromise);
+
+      const source = createActionSource(true);
+      const store = new LinkTxCartStore(source);
+      mockTwoRowAssets();
+      store.initializeAssets({});
+      store.initialize();
+
+      const executePromise = store.execute();
+      await vi.waitFor(() => store.phase === TxProgressPhase.FE_PHASE);
+
+      const onRequestSettled = mockSendBatchRequest.mock.calls[0][3] as (
+        intentIds: string[],
+        success: boolean,
+      ) => void;
+      // A single merged ICRC-112 request settling for both intents.
+      onRequestSettled(["intent-1", "intent-2"], true);
+
+      expect(store.assetAndFeeList[0].asset.state).toBe(
+        AssetProcessState.SIGNED_PENDING,
+      );
+      expect(store.assetAndFeeList[1].asset.state).toBe(
+        AssetProcessState.SIGNED_PENDING,
+      );
+
+      resolveIcrc!({ isSuccess: true });
+      await executePromise;
+    });
+
+    it("should_reach_signed_pending_via_fallback_for_a_row_never_reported_by_progress", async () => {
+      let resolveProcess: (v: ProcessActionResult) => void;
+      const processPromise = new Promise<ProcessActionResult>((resolve) => {
+        resolveProcess = resolve;
+      });
+
+      const source = createActionSource(true);
+      vi.mocked(source.handleProcessAction).mockReturnValueOnce(processPromise);
+
+      const store = new LinkTxCartStore(source);
+      mockTwoRowAssets();
+      store.initializeAssets({});
+      store.initialize();
+
+      // Default mockSendBatchRequest resolves success without ever invoking
+      // onRequestSettled - simulating an intent that never produced a wallet tx.
+      const executePromise = store.execute();
+      await vi.waitFor(() => store.phase === TxProgressPhase.BE_PHASE);
+
+      expect(store.assetAndFeeList[0].asset.state).toBe(
+        AssetProcessState.SIGNED_PENDING,
+      );
+      expect(store.assetAndFeeList[1].asset.state).toBe(
+        AssetProcessState.SIGNED_PENDING,
+      );
+
+      resolveProcess!({
+        action: createMockAction(),
+        isSuccess: true,
+        errors: [],
+      });
+      await executePromise;
     });
   });
 

--- a/src/cashier_frontend_new/src/modules/transactionCart/state/linkTxCartStore.svelte.ts
+++ b/src/cashier_frontend_new/src/modules/transactionCart/state/linkTxCartStore.svelte.ts
@@ -161,6 +161,32 @@ export class LinkTxCartStore implements TxCartStore {
   }
 
   /**
+   * Incrementally transition rows as individual ICRC-112 sub-requests settle,
+   * instead of waiting for the whole batch to resolve. Only touches rows
+   * currently PROCESSING (never regresses a row a later phase already moved
+   * past). When one physical ICRC-112 call represents more than one intent
+   * (backend-side merge), every matching row flips together, honestly
+   * reflecting that they share one on-chain call.
+   */
+  applyBatchProgress(intentIds: string[], success: boolean): void {
+    if (intentIds.length === 0) return;
+    this.#assetAndFeeList = this.#assetAndFeeList.map((item) => {
+      if (!item.asset.intentId || !intentIds.includes(item.asset.intentId))
+        return item;
+      if (item.asset.state !== AssetProcessState.PROCESSING) return item;
+      return {
+        ...item,
+        asset: {
+          ...item.asset,
+          state: success
+            ? AssetProcessState.SIGNED_PENDING
+            : AssetProcessState.FAILED,
+        },
+      };
+    });
+  }
+
+  /**
    * Execute action transaction (ICRC-112 batch + processAction).
    * Transitions: CREATED → PROCESSING → [SIGNED_PENDING after ICRC-112] → SUCCEED after backend
    * @returns ProcessActionResult from handleProcessAction
@@ -187,6 +213,7 @@ export class LinkTxCartStore implements TxCartStore {
           action.icrc_112_requests,
           authState.account!.owner,
           CASHIER_BACKEND_CANISTER_ID,
+          (intentIds, success) => this.applyBatchProgress(intentIds, success),
         );
         if (!icrcResult.isSuccess) {
           this.#phase = TxProgressPhase.IDLE;
@@ -205,14 +232,17 @@ export class LinkTxCartStore implements TxCartStore {
       // Completed: all transactions done
       this.#phase = TxProgressPhase.COMPLETED;
 
-      // When backend reports is_success: true, show full green checkmarks
-      if (result.isSuccess) {
+      // Prefer the authoritative per-intent state from the backend when available,
+      // on both success and partial-failure - more correct than assuming
+      // isSuccess implies every row is SUCCEED (e.g. an intent that never
+      // needed a wallet tx keeps its own true state).
+      if (result.action) {
+        this.syncStatesFromAction(result.action);
+      } else if (result.isSuccess) {
         this.#assetAndFeeList = this.#assetAndFeeList.map((item) => ({
           ...item,
           asset: { ...item.asset, state: AssetProcessState.SUCCEED },
         }));
-      } else if (result.action) {
-        this.syncStatesFromAction(result.action);
       }
 
       return result;

--- a/src/integration_tests/tests/cashier_backend/link_v3/send_tip/create_link.rs
+++ b/src/integration_tests/tests/cashier_backend/link_v3/send_tip/create_link.rs
@@ -158,6 +158,17 @@ async fn it_should_create_icp_token_tip_link_successfully() {
                         }
                     );
                     assert!(approve_args.amount > tip_amount.clone());
+
+                    // Both the fee and asset intents approve the same ICP asset
+                    // to the same spender, so the backend merges their
+                    // transactions into a single ICRC-112 request. The
+                    // `intent_ids` field must preserve both contributing
+                    // intents, not just one, so the FE can update both rows.
+                    let mut intent_ids = req.intent_ids.clone();
+                    intent_ids.sort();
+                    let mut expected_ids = vec![fee_intent.id.clone(), asset_intent.id.clone()];
+                    expected_ids.sort();
+                    assert_eq!(intent_ids, expected_ids);
                 }
                 _ => panic!("Unexpected method in ICRC-112 request"),
             }
@@ -285,8 +296,13 @@ async fn it_should_create_icrc_token_tip_link_successfully() {
 
                     if req.canister_id == Principal::from_text(ICP_PRINCIPAL).unwrap() {
                         assert!(approve_args.amount > icp_fee.clone());
+                        // Different asset (ICP fee vs CKBTC asset) means no
+                        // protocol-key merge, so this request maps to exactly
+                        // the fee intent.
+                        assert_eq!(req.intent_ids, vec![fee_intent.id.clone()]);
                     } else {
                         assert!(approve_args.amount > tip_amount.clone());
+                        assert_eq!(req.intent_ids, vec![asset_intent.id.clone()]);
                     }
                 }
                 _ => panic!("Unexpected method in ICRC-112 request"),

--- a/src/transaction_manager/src/icrc112/mod.rs
+++ b/src/transaction_manager/src/icrc112/mod.rs
@@ -21,7 +21,29 @@ use icrc_ledger_types::{
     icrc1::{account::Account, transfer::TransferArg},
     icrc2::approve::ApproveArgs,
 };
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
+
+/// Builds a reverse lookup of transaction id -> the intent id(s) that own it.
+/// # Arguments
+/// * `intent_txs_map` - A mapping of intent id -> its transactions, used to tag
+///   each resulting request with the intent(s) it belongs to
+/// # Returns
+/// * `HashMap<String, Vec<String>>` - A map of transaction ids to their owning intent ids
+fn build_tx_id_to_intent_ids(
+    intent_txs_map: &HashMap<String, Vec<Transaction>>,
+) -> HashMap<String, Vec<String>> {
+    let mut map: HashMap<String, BTreeSet<String>> = HashMap::new();
+    for (intent_id, txs) in intent_txs_map.iter() {
+        for tx in txs.iter() {
+            map.entry(tx.id.clone())
+                .or_default()
+                .insert(intent_id.clone());
+        }
+    }
+    map.into_iter()
+        .map(|(tx_id, ids)| (tx_id, ids.into_iter().collect()))
+        .collect()
+}
 
 /// Creates ICRC-112 requests from a list of transactions
 /// The input transactions are topologically sorted based on their dependencies,
@@ -31,6 +53,8 @@ use std::collections::HashMap;
 /// * `link_account` - The account to which the tokens will be transferred
 /// * `canister_id` - The canister ID of the token contract
 /// * `current_ts` - The current timestamp to be used for created_at_time fields
+/// * `intent_txs_map` - Mapping of intent id -> its transactions, used to tag
+///   each resulting request with the intent(s) it belongs to
 /// # Returns
 /// * `Result<Icrc112Requests, CanisterError>` - The resulting Icrc112Requests or an error
 pub fn create_icrc_112_requests(
@@ -38,6 +62,7 @@ pub fn create_icrc_112_requests(
     link_account: Account,
     canister_id: Principal,
     current_ts: u64,
+    intent_txs_map: &HashMap<String, Vec<Transaction>>,
 ) -> Result<Icrc112Requests, CanisterError> {
     // update timestamps of ICRC transactions
     for tx in transactions.iter_mut() {
@@ -57,8 +82,12 @@ pub fn create_icrc_112_requests(
         .filter(|tx| tx.state == TransactionState::Created || tx.state == TransactionState::Fail)
         .collect();
 
+    // reverse lookup: tx id -> owning intent id(s), built before any merging
+    let tx_id_to_intent_ids = build_tx_id_to_intent_ids(intent_txs_map);
+
     // merge transactions by protocol key
-    let wallet_transactions = merge_transactions_by_protocol_key(wallet_transactions);
+    let (wallet_transactions, merged_tx_id_to_intent_ids) =
+        merge_transactions_by_protocol_key(wallet_transactions, &tx_id_to_intent_ids);
 
     let tx_graph: Graph = wallet_transactions.clone().into();
     let sorted_txs = kahn_topological_sort(&tx_graph)?;
@@ -73,8 +102,12 @@ pub fn create_icrc_112_requests(
         let mut group_requests = Vec::<Icrc112Request>::new();
         for tx_id in tx_group.iter() {
             if let Some(tx) = tx_map.get_mut(tx_id) {
+                let intent_ids = merged_tx_id_to_intent_ids
+                    .get(tx_id)
+                    .cloned()
+                    .unwrap_or_default();
                 let icrc_112_request =
-                    convert_tx_to_icrc_112_request(tx, link_account, canister_id)?;
+                    convert_tx_to_icrc_112_request(tx, link_account, canister_id, intent_ids)?;
                 group_requests.push(icrc_112_request);
             }
         }
@@ -89,11 +122,18 @@ pub fn create_icrc_112_requests(
 /// Merges transactions that share the same protocol key.
 /// # Arguments
 /// * `transactions` - A vector of Transactions to be merged.
+/// * `tx_id_to_intent_ids` - Reverse lookup of original transaction id -> owning intent id(s).
 /// # Returns
-/// * `Vec<Transaction>` - A vector of merged Transactions.
-pub fn merge_transactions_by_protocol_key(transactions: Vec<Transaction>) -> Vec<Transaction> {
+/// * `(Vec<Transaction>, HashMap<String, Vec<String>>)` - The merged transactions, and a map
+///   from each resulting (representative) transaction id to the union of intent ids
+///   contributed by every original transaction folded into it.
+pub fn merge_transactions_by_protocol_key(
+    transactions: Vec<Transaction>,
+    tx_id_to_intent_ids: &HashMap<String, Vec<String>>,
+) -> (Vec<Transaction>, HashMap<String, Vec<String>>) {
     let mut merged_map: HashMap<String, Vec<Transaction>> = HashMap::new();
     let mut merged_transactions: Vec<Transaction> = Vec::new();
+    let mut merged_tx_id_to_intent_ids: HashMap<String, Vec<String>> = HashMap::new();
 
     for tx in transactions.into_iter() {
         merged_map
@@ -104,7 +144,10 @@ pub fn merge_transactions_by_protocol_key(transactions: Vec<Transaction>) -> Vec
 
     for (_key, tx_group) in merged_map.into_iter() {
         if tx_group.len() == 1 {
-            merged_transactions.push(tx_group.into_iter().next().unwrap());
+            let tx = tx_group.into_iter().next().unwrap();
+            let intent_ids = tx_id_to_intent_ids.get(&tx.id).cloned().unwrap_or_default();
+            merged_tx_id_to_intent_ids.insert(tx.id.clone(), intent_ids);
+            merged_transactions.push(tx);
         } else {
             // sort the transactions by id before merging to ensure deterministic behavior
             let mut sorted_tx_group = tx_group;
@@ -115,11 +158,20 @@ pub fn merge_transactions_by_protocol_key(transactions: Vec<Transaction>) -> Vec
                 merged_tx.merge_with(tx);
             }
 
+            // union intent ids across every original transaction in this group,
+            // not just the representative, so cross-intent merges are preserved
+            let intent_ids: BTreeSet<String> = sorted_tx_group
+                .iter()
+                .flat_map(|tx| tx_id_to_intent_ids.get(&tx.id).cloned().unwrap_or_default())
+                .collect();
+
+            merged_tx_id_to_intent_ids
+                .insert(merged_tx.id.clone(), intent_ids.into_iter().collect());
             merged_transactions.push(merged_tx);
         }
     }
 
-    merged_transactions
+    (merged_transactions, merged_tx_id_to_intent_ids)
 }
 
 /// Converts a Transaction to an Icrc112Request for ICRC-1 or ICRC-2 token transfers.
@@ -127,12 +179,14 @@ pub fn merge_transactions_by_protocol_key(transactions: Vec<Transaction>) -> Vec
 /// * `tx` - The transaction to convert.
 /// * `link_account` - The account to which the tokens will be transferred.
 /// * `canister_id` - The canister ID of the token contract.
+/// * `intent_ids` - The intent id(s) that own this (possibly merged) transaction.
 /// # Returns
 /// * `Result<Icrc112Request, CanisterError>` - The resulting Icrc112Request or an error if the conversion fails.
 pub fn convert_tx_to_icrc_112_request(
     tx: &mut Transaction,
     link_account: Account,
     canister_id: Principal,
+    intent_ids: Vec<String>,
 ) -> Result<Icrc112Request, CanisterError> {
     match &mut tx.protocol {
         Protocol::IC(IcTransaction::Icrc1Transfer(tx_transfer)) => {
@@ -168,6 +222,7 @@ pub fn convert_tx_to_icrc_112_request(
                 method: canister_call.method,
                 arg: canister_call.arg,
                 nonce: Some(nonce),
+                intent_ids,
             })
         }
         Protocol::IC(IcTransaction::Icrc2Approve(tx_approve)) => {
@@ -209,6 +264,7 @@ pub fn convert_tx_to_icrc_112_request(
                 method: canister_call.method,
                 arg: canister_call.arg,
                 nonce: Some(nonce),
+                intent_ids,
             })
         }
         _ => Err(CanisterError::HandleLogicError(
@@ -262,10 +318,12 @@ mod tests {
             subaccount: None,
         };
         let canister_id = random_principal_id();
+        let intent_ids = vec!["intent-1".to_string()];
 
         // Act
         let icrc_112_request =
-            convert_tx_to_icrc_112_request(&mut tx, link_account, canister_id).unwrap();
+            convert_tx_to_icrc_112_request(&mut tx, link_account, canister_id, intent_ids.clone())
+                .unwrap();
 
         // Assert
         assert_eq!(
@@ -279,6 +337,7 @@ mod tests {
             }
         );
         assert_eq!(icrc_112_request.method, "icrc1_transfer");
+        assert_eq!(icrc_112_request.intent_ids, intent_ids);
     }
 
     #[test]
@@ -315,10 +374,12 @@ mod tests {
             subaccount: None,
         };
         let canister_id = random_principal_id();
+        let intent_ids = vec!["intent-1".to_string()];
 
         // Act
         let icrc_112_request =
-            convert_tx_to_icrc_112_request(&mut tx, link_account, canister_id).unwrap();
+            convert_tx_to_icrc_112_request(&mut tx, link_account, canister_id, intent_ids.clone())
+                .unwrap();
 
         // Assert
         assert_eq!(
@@ -331,6 +392,7 @@ mod tests {
             }
         );
         assert_eq!(icrc_112_request.method, "icrc2_approve");
+        assert_eq!(icrc_112_request.intent_ids, intent_ids);
     }
 
     #[test]
@@ -391,15 +453,33 @@ mod tests {
         };
         let canister_id = random_principal_id();
         let current_ts = 1_632_192_100_000_000_000;
+        let intent_txs_map = HashMap::from([
+            ("intent-1".to_string(), vec![tx1.clone()]),
+            ("intent-2".to_string(), vec![tx2.clone()]),
+        ]);
 
         // Act
-        let icrc_112_requests =
-            create_icrc_112_requests(&mut transactions, link_account, canister_id, current_ts)
-                .unwrap();
+        let icrc_112_requests = create_icrc_112_requests(
+            &mut transactions,
+            link_account,
+            canister_id,
+            current_ts,
+            &intent_txs_map,
+        )
+        .unwrap();
 
         // Assert
         assert_eq!(icrc_112_requests.len(), 1);
         assert_eq!(icrc_112_requests[0].len(), 2);
+        let mut request_intent_ids: Vec<Vec<String>> = icrc_112_requests[0]
+            .iter()
+            .map(|r| r.intent_ids.clone())
+            .collect();
+        request_intent_ids.sort();
+        assert_eq!(
+            request_intent_ids,
+            vec![vec!["intent-1".to_string()], vec!["intent-2".to_string()]]
+        );
     }
 
     #[test]
@@ -466,9 +546,14 @@ mod tests {
         };
 
         let transactions = vec![tx1, tx2];
+        let tx_id_to_intent_ids = HashMap::from([
+            (tx1_id.clone(), vec!["intent-1".to_string()]),
+            (tx2_id.clone(), vec!["intent-2".to_string()]),
+        ]);
 
         // Act
-        let merged_transactions = merge_transactions_by_protocol_key(transactions);
+        let (merged_transactions, merged_tx_id_to_intent_ids) =
+            merge_transactions_by_protocol_key(transactions, &tx_id_to_intent_ids);
 
         // Assert
         assert_eq!(merged_transactions.len(), 1);
@@ -480,6 +565,15 @@ mod tests {
         } else {
             panic!("Merged transaction is not an ICRC-2 Approve");
         }
+        let mut intent_ids = merged_tx_id_to_intent_ids
+            .get(&merged_transactions[0].id)
+            .cloned()
+            .unwrap();
+        intent_ids.sort();
+        assert_eq!(
+            intent_ids,
+            vec!["intent-1".to_string(), "intent-2".to_string()]
+        );
     }
 
     #[test]
@@ -546,9 +640,14 @@ mod tests {
         };
 
         let transactions = vec![tx1, tx2];
+        let tx_id_to_intent_ids = HashMap::from([
+            (tx1_id.clone(), vec!["intent-1".to_string()]),
+            (tx2_id.clone(), vec!["intent-1".to_string()]),
+        ]);
 
         // Act
-        let merged_transactions = merge_transactions_by_protocol_key(transactions);
+        let (merged_transactions, merged_tx_id_to_intent_ids) =
+            merge_transactions_by_protocol_key(transactions, &tx_id_to_intent_ids);
 
         // Assert
         assert_eq!(merged_transactions.len(), 1);
@@ -560,6 +659,10 @@ mod tests {
         } else {
             panic!("Merged transaction is not an ICRC-1 Transfer");
         }
+        assert_eq!(
+            merged_tx_id_to_intent_ids.get(&merged_transactions[0].id),
+            Some(&vec!["intent-1".to_string()])
+        );
     }
 
     #[test]
@@ -626,7 +729,7 @@ mod tests {
             group: 1u16,
         };
 
-        let mut transactions = vec![tx1, tx2];
+        let mut transactions = vec![tx1.clone(), tx2.clone()];
 
         let link_account = Account {
             owner: random_principal_id(),
@@ -634,11 +737,20 @@ mod tests {
         };
         let canister_id = random_principal_id();
         let current_ts = 1_632_192_300_000_000_000;
+        let intent_txs_map = HashMap::from([
+            ("gate_fee_intent".to_string(), vec![tx1]),
+            ("link_creation_fee_intent".to_string(), vec![tx2]),
+        ]);
 
         // Act
-        let icrc_112_requests =
-            create_icrc_112_requests(&mut transactions, link_account, canister_id, current_ts)
-                .unwrap();
+        let icrc_112_requests = create_icrc_112_requests(
+            &mut transactions,
+            link_account,
+            canister_id,
+            current_ts,
+            &intent_txs_map,
+        )
+        .unwrap();
 
         // Assert
         assert_eq!(icrc_112_requests.len(), 1);
@@ -648,5 +760,143 @@ mod tests {
         let icrc2_approve_args = Decode!(icrc112_request.arg.as_slice(), ApproveArgs).unwrap();
         assert_eq!(icrc2_approve_args.amount, Nat::from(800u64));
         assert_eq!(icrc2_approve_args.created_at_time, Some(merged_ts));
+
+        // Two different intents (gate fee + link creation fee) merged into a single
+        // ICRC-112 request must preserve both intent ids, not just the representative's.
+        let mut intent_ids = icrc112_request.intent_ids.clone();
+        intent_ids.sort();
+        assert_eq!(
+            intent_ids,
+            vec![
+                "gate_fee_intent".to_string(),
+                "link_creation_fee_intent".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn it_should_propagate_single_intent_id_to_icrc112_request() {
+        // Arrange
+        let created_at = 1_632_192_000_000_000_000u64;
+        let start_ts = 1_632_192_100_000_000_000u64;
+        let asset = Asset::default();
+        let amount = Nat::from(1000u64);
+        let from = Wallet::new(random_principal_id());
+        let to = Wallet::new(random_principal_id());
+        let memo = Some(Memo::default());
+        let tx_id = random_id_string();
+
+        let tx = Transaction {
+            id: tx_id.clone(),
+            from_call_type: FromCallType::Wallet,
+            state: TransactionState::Created,
+            protocol: Protocol::IC(IcTransaction::Icrc1Transfer(Icrc1Transfer {
+                from,
+                to,
+                asset,
+                amount,
+                memo,
+                ts: Some(start_ts),
+            })),
+            dependency: None,
+            created_at,
+            start_ts: Some(start_ts),
+            group: 1u16,
+        };
+
+        let mut transactions = vec![tx.clone()];
+        let link_account = Account {
+            owner: random_principal_id(),
+            subaccount: None,
+        };
+        let canister_id = random_principal_id();
+        let current_ts = 1_632_192_200_000_000_000;
+        let intent_txs_map = HashMap::from([("intent-only".to_string(), vec![tx])]);
+
+        // Act
+        let icrc_112_requests = create_icrc_112_requests(
+            &mut transactions,
+            link_account,
+            canister_id,
+            current_ts,
+            &intent_txs_map,
+        )
+        .unwrap();
+
+        // Assert
+        assert_eq!(icrc_112_requests.len(), 1);
+        assert_eq!(icrc_112_requests[0].len(), 1);
+        assert_eq!(
+            icrc_112_requests[0][0].intent_ids,
+            vec!["intent-only".to_string()]
+        );
+    }
+
+    #[test]
+    fn it_should_propagate_shared_tx_id_across_multiple_intents() {
+        // Arrange: a single transaction already assigned to two different intents in
+        // intent_txs_map (simulating merge_fee_transactions_by_group's upstream merge),
+        // with no protocol-key merge involved.
+        let created_at = 1_632_192_000_000_000_000u64;
+        let start_ts = 1_632_192_100_000_000_000u64;
+        let asset = Asset::default();
+        let amount = Nat::from(500u64);
+        let from = Wallet::new(random_principal_id());
+        let spender = Wallet::new(random_principal_id());
+        let memo = Some(Memo::default());
+        let tx_id = random_id_string();
+
+        let tx = Transaction {
+            id: tx_id.clone(),
+            from_call_type: FromCallType::Wallet,
+            state: TransactionState::Created,
+            protocol: Protocol::IC(IcTransaction::Icrc2Approve(Icrc2Approve {
+                from,
+                spender,
+                asset,
+                amount,
+                memo,
+                ts: Some(start_ts),
+            })),
+            dependency: None,
+            created_at,
+            start_ts: Some(start_ts),
+            group: 1u16,
+        };
+
+        let mut transactions = vec![tx.clone()];
+        let link_account = Account {
+            owner: random_principal_id(),
+            subaccount: None,
+        };
+        let canister_id = random_principal_id();
+        let current_ts = 1_632_192_200_000_000_000;
+        let intent_txs_map = HashMap::from([
+            ("gate_fee_intent".to_string(), vec![tx.clone()]),
+            ("link_creation_fee_intent".to_string(), vec![tx]),
+        ]);
+
+        // Act
+        let icrc_112_requests = create_icrc_112_requests(
+            &mut transactions,
+            link_account,
+            canister_id,
+            current_ts,
+            &intent_txs_map,
+        )
+        .unwrap();
+
+        // Assert
+        assert_eq!(icrc_112_requests.len(), 1);
+        assert_eq!(icrc_112_requests[0].len(), 1);
+        let mut intent_ids = icrc_112_requests[0][0].intent_ids.clone();
+        intent_ids.sort();
+        assert_eq!(
+            intent_ids,
+            vec![
+                "gate_fee_intent".to_string(),
+                "link_creation_fee_intent".to_string()
+            ]
+        );
     }
 }

--- a/src/transaction_manager/src/v2/ic_transaction_manager.rs
+++ b/src/transaction_manager/src/v2/ic_transaction_manager.rs
@@ -113,8 +113,13 @@ impl<E: IcEnvironment> TransactionManager for IcTransactionManager<E> {
         let canister_id = self.ic_env.id();
         let link_account = get_link_account(&action.link_id, canister_id)?;
 
-        let icrc112_requests =
-            create_icrc_112_requests(&mut transactions, link_account, canister_id, current_ts)?;
+        let icrc112_requests = create_icrc_112_requests(
+            &mut transactions,
+            link_account,
+            canister_id,
+            current_ts,
+            &intent_txs_map,
+        )?;
 
         Ok(CreateActionResult {
             action,
@@ -188,6 +193,7 @@ impl<E: IcEnvironment> TransactionManager for IcTransactionManager<E> {
                 link_account,
                 canister_id,
                 current_ts,
+                &intent_txs_map,
             )?;
 
             // update intent_txs_map with processed transactions
@@ -284,5 +290,9 @@ pub mod tests {
         assert!(!requests.is_empty());
         // and each request group should contain at least one request
         assert!(requests.iter().all(|group| !group.is_empty()));
+        // The manager must thread `intent_txs_map` through to
+        // `create_icrc_112_requests` so each request is tagged with the
+        // intent(s) that produced it.
+        assert_eq!(requests[0][0].intent_ids, vec![intent.id.clone()]);
     }
 }

--- a/src/transaction_manager/src/v3/ic_transaction_manager.rs
+++ b/src/transaction_manager/src/v3/ic_transaction_manager.rs
@@ -222,8 +222,13 @@ impl<E: IcEnvironment> TransactionManagerV3 for IcTransactionManager<E> {
         // create ICRC112 requests from transactions
         let canister_id = self.ic_env.id();
         let link_account = get_link_account(&action.link_id, canister_id)?;
-        let icrc112_requests =
-            create_icrc_112_requests(&mut transactions, link_account, canister_id, current_ts)?;
+        let icrc112_requests = create_icrc_112_requests(
+            &mut transactions,
+            link_account,
+            canister_id,
+            current_ts,
+            &intent_txs_map,
+        )?;
 
         Ok(CreateActionResultV3 {
             action,
@@ -295,6 +300,7 @@ impl<E: IcEnvironment> TransactionManagerV3 for IcTransactionManager<E> {
                 link_account,
                 canister_id,
                 current_ts,
+                &intent_txs_map,
             )?;
 
             // update intent_txs_map with processed transactions
@@ -799,7 +805,12 @@ mod tests {
         let result = result.unwrap();
         assert!(result.intent_txs_map.contains_key(&intent.id));
         assert!(result.icrc112_requests.is_some());
-        assert!(!result.icrc112_requests.unwrap().is_empty());
+        let icrc112_requests = result.icrc112_requests.unwrap();
+        assert!(!icrc112_requests.is_empty());
+        // The manager must thread `intent_txs_map` through to
+        // `create_icrc_112_requests` so each request is tagged with the
+        // intent(s) that produced it.
+        assert_eq!(icrc112_requests[0][0].intent_ids, vec![intent.id.clone()]);
     }
 
     #[tokio::test]
@@ -917,5 +928,64 @@ mod tests {
         assert!(result.errors.is_empty());
         assert!(*rollup_called.borrow());
         assert_eq!(*execute_called.borrow(), 0);
+    }
+
+    #[tokio::test]
+    async fn it_should_tag_retry_icrc112_requests_with_intent_ids_after_process_action() {
+        // Arrange: a wallet transaction that failed validation - process_action's
+        // `create_icrc_112_requests` call regenerates ICRC-112 requests from
+        // CREATED/FAILED wallet transactions so the FE can retry them, and
+        // those regenerated requests must still carry the correct intent_ids.
+        let manager = fixture_of_manager();
+        let action = fixture_of_action_v3("11111111-1111-1111-1111-111111111111");
+        let intent = fixture_of_intent_v3("intent_v3_id");
+        let tx = fixture_of_wallet_transaction_created("11111111-2222-3333-4444-555555555555");
+        let mut tx_failed = tx.clone();
+        tx_failed.state = TransactionState::Fail;
+        let intent_txs_map = fixture_of_intent_txs_map(&intent.id, vec![tx]);
+
+        let rollup_called = Rc::new(RefCell::new(false));
+        let execute_called = Rc::new(RefCell::new(0));
+        let validation_service = MockValidationService {
+            validate_result: Ok(ValidateActionTransactionsResult {
+                wallet_transactions: vec![tx_failed],
+                canister_transactions: vec![],
+                is_success: false,
+                errors: vec!["wallet tx failed".to_string()],
+            }),
+            rollup_result_v3: Ok(fixture_of_rollup_result_v3(
+                action.clone(),
+                vec![intent.clone()],
+            )),
+            rollup_called: rollup_called.clone(),
+        };
+        let execution_service = MockExecutionService {
+            execute_result: Ok(ExecuteTransactionsResult {
+                transactions: vec![],
+                is_success: true,
+                errors: vec![],
+            }),
+            execute_called: execute_called.clone(),
+        };
+
+        // Act
+        let result = manager
+            .process_action(
+                action,
+                vec![intent.clone()],
+                intent_txs_map,
+                validation_service,
+                execution_service,
+            )
+            .await;
+
+        // Assert
+        assert!(result.is_ok());
+        let result = result.unwrap();
+        assert!(!result.is_success);
+        assert!(result.icrc112_requests.is_some());
+        let icrc112_requests = result.icrc112_requests.unwrap();
+        assert!(!icrc112_requests.is_empty());
+        assert_eq!(icrc112_requests[0][0].intent_ids, vec![intent.id.clone()]);
     }
 }


### PR DESCRIPTION
This PR includes:
- update BE to associate intent metadata to icrc112 requests
- update FE to listen to transaction execution event to render state on tx-cart accordingly
- add unit tests
- add integration tests