### PR TITLE
[Bugfix] Fix stale transaction cart amount on wallet send

### DIFF
--- a/src/cashier_frontend_new/src/modules/creationLink/components/shared/AssetButton.svelte
+++ b/src/cashier_frontend_new/src/modules/creationLink/components/shared/AssetButton.svelte
@@ -224,6 +224,7 @@
                 style="width: {inputWidth}; max-width: 92px; position: relative; z-index: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;"
                 placeholder="0"
                 inputmode="decimal"
+                autocomplete="off"
               />
             </div>
           {/if}

--- a/src/cashier_frontend_new/src/modules/transactionCart/components/WalletTxCart.svelte
+++ b/src/cashier_frontend_new/src/modules/transactionCart/components/WalletTxCart.svelte
@@ -134,20 +134,16 @@
   });
 
   /**
-   * Update source when prop changes.
+   * Keep the transfer source and its derived preview rows in sync.
+   * updateSource() clears stale rows when the transfer changes, after which
+   * initializeAssets() rebuilds them from the current amount and token data.
    */
   $effect(() => {
     if (walletTxCartStore && source) {
       walletTxCartStore.updateSource(source);
-    }
-  });
-
-  /**
-   * Initialize assets when tokens available or source changes.
-   */
-  $effect(() => {
-    if (walletTxCartStore && Object.keys(tokensMap).length > 0) {
-      walletTxCartStore.initializeAssets(tokensMap);
+      if (Object.keys(tokensMap).length > 0) {
+        walletTxCartStore.initializeAssets(tokensMap);
+      }
     }
   });
 </script>

--- a/src/cashier_frontend_new/src/modules/transactionCart/state/walletTxCartStore.spec.ts
+++ b/src/cashier_frontend_new/src/modules/transactionCart/state/walletTxCartStore.spec.ts
@@ -260,6 +260,61 @@ describe("WalletTxCartStore", () => {
       expect(store.assetAndFeeList[0].asset.symbol).toBe("TEST");
       expect(mockMapWalletToAssetAndFeeList).toHaveBeenCalledTimes(1);
     });
+
+    it("should keep the preview and execution amount aligned after an amount change", async () => {
+      const source = createWalletSource();
+      const store = new WalletTxCartStore(source);
+
+      store.initialize();
+      store.initializeAssets({});
+
+      mockMapWalletToAssetAndFeeList.mockReturnValue([
+        {
+          asset: {
+            state: AssetProcessState.CREATED,
+            label: "",
+            symbol: "TEST",
+            address: "test-token-address",
+            amount: 20_000n,
+            amountFormattedStr: "0.0002",
+            usdValueStr: "$0.0004",
+            direction: FlowDirection.OUTGOING,
+          },
+          fee: {
+            feeType: FeeType.NETWORK_FEE,
+            amount: 10_000n,
+            amountFormattedStr: "0.0001",
+            symbol: "TEST",
+            usdValue: 0.0001,
+          },
+        },
+      ]);
+
+      store.updateSource({ ...source, amount: 10_000n });
+      store.initializeAssets({});
+
+      expect(mockMapWalletToAssetAndFeeList).toHaveBeenLastCalledWith(
+        {
+          amount: 10_000n,
+          tokenAddress: source.token.address,
+        },
+        {},
+      );
+      expect(store.assetAndFeeList[0].asset.amount).toBe(20_000n);
+      expect(store.assetAndFeeList[0].asset.amountFormattedStr).toBe("0.0002");
+      expect(mockMapWalletToAssetAndFeeList).toHaveBeenCalledTimes(2);
+
+      await store.execute();
+
+      expect(mockTransferToPrincipal).toHaveBeenCalledWith(
+        source.to,
+        10_000n,
+        expect.objectContaining({
+          memo: expect.any(Uint8Array),
+          createdAtTime: expect.any(BigInt),
+        }),
+      );
+    });
   });
 
   describe("computeFee", () => {

--- a/src/cashier_frontend_new/src/modules/transactionCart/state/walletTxCartStore.svelte.ts
+++ b/src/cashier_frontend_new/src/modules/transactionCart/state/walletTxCartStore.svelte.ts
@@ -34,10 +34,38 @@ export class WalletTxCartStore implements TxCartStore {
 
   /**
    * Update the source reference for reactive updates.
-   * Call this from $effect when source prop changes.
+   *
+   * A changed transfer represents a new confirmation attempt. Clear the
+   * previously derived cart rows so initializeAssets() rebuilds the preview
+   * from the same source that execute() will submit.
    */
   updateSource(newSource: WalletSource): void {
+    const tokenChanged = this.#source.token.address !== newSource.token.address;
+    const transferChanged =
+      tokenChanged ||
+      this.#source.amount !== newSource.amount ||
+      this.#source.receiveType !== newSource.receiveType ||
+      this.#destinationKey(this.#source.to) !==
+        this.#destinationKey(newSource.to);
+
     this.#source = newSource;
+
+    if (!transferChanged) return;
+
+    this.#assetAndFeeList = [];
+    this.#deduplication = this.#createDeduplicationFields();
+
+    if (tokenChanged) {
+      this.#icpLedgerService = null;
+      this.#icrcLedgerService = null;
+      this.initialize();
+    }
+  }
+
+  #destinationKey(destination: WalletSource["to"]): string {
+    return typeof destination === "string"
+      ? `account:${destination}`
+      : `principal:${destination.toText()}`;
   }
 
   /** Reactive asset and fee list for UI */


### PR DESCRIPTION
Fixes the wallet send confirmation drawer retaining a previously derived amount after the form amount changes. The cart now invalidates and rebuilds its preview rows when the transfer source changes, keeping the displayed total aligned with the amount submitted to the ledger. Adds regression coverage for changing 0.01 ICP to 0.0001 ICP and verifying the 0.0002 ICP total including fee.